### PR TITLE
Add expressions interning

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,7 @@
 object Versions {
-    const val ksmt = "0.3.1"
+    const val ksmt = "0.3.2"
     const val collections = "0.3.5"
     const val coroutines = "1.6.4"
     const val jcdb = "a5c479bcf8"
+    const val mockk = "1.13.4"
 }

--- a/usvm-core/build.gradle.kts
+++ b/usvm-core/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
     implementation("com.github.UnitTestBot.ksmt:ksmt-z3:${Versions.ksmt}")
 
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:${Versions.collections}")
+    testImplementation("io.mockk:mockk:${Versions.mockk}")
 }

--- a/usvm-core/src/main/kotlin/org/usvm/Context.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Context.kt
@@ -2,36 +2,132 @@ package org.usvm
 
 import org.ksmt.KAst
 import org.ksmt.KContext
+import org.ksmt.cache.AstInterner
+import org.ksmt.cache.KInternedObject
 import org.ksmt.solver.model.DefaultValueSampler.Companion.sampleValue
 import org.ksmt.utils.asExpr
+import org.ksmt.utils.cast
 
-open class UContext: KContext() {
-    // TODO: Caches
-    // TODO: mk functions for new expressions
-
+@Suppress("LeakingThis")
+open class UContext(
+    private val operationMode: OperationMode = OperationMode.CONCURRENT, // TODO replace it when we have KSMT 0.3.3 version
+    private val astManagementMode: AstManagementMode = AstManagementMode.GC // TODO replace it when we have KSMT 0.3.3 version
+) : KContext(operationMode, astManagementMode) {
     val addressSort: UAddressSort = UAddressSort(this)
     val sizeSort: USizeSort = mkBv32Sort()
 
     val zeroSize: USizeExpr = sizeSort.sampleValue()
 
-    val nullRef = UConcreteHeapRef(nullAddress, this)
+    val nullRef = UConcreteHeapRef(this, nullAddress)
 
-    fun <Sort: USort> mkDefault(sort: Sort): UExpr<Sort> =
-        when(sort) {
+    private val uConcreteHeapRefCache = mkAstInterner<UConcreteHeapRef>()
+    fun mkConcreteHeapRef(address: UHeapAddress): UConcreteHeapRef =
+        uConcreteHeapRefCache.createIfContextActive {
+            UConcreteHeapRef(this, address)
+        }
+
+    private val registerReadingCache = mkAstInterner<URegisterReading>()
+    fun mkRegisterReading(idx: Int, sort: USort): URegisterReading =
+        registerReadingCache.createIfContextActive {
+            URegisterReading(this, idx, sort)
+        }.cast()
+
+    private val inputFieldReadingCache = mkAstInterner<UFieldReading<Any>>()
+
+    fun <Field> mkFieldReading(
+        region: UVectorMemoryRegion<USort>,
+        address: UHeapRef,
+        field: Field
+    ): UFieldReading<Field> = inputFieldReadingCache.createIfContextActive {
+        UFieldReading(this, region, address, field.cast())
+    }.cast()
+
+    private val allocatedArrayReadingCache = mkAstInterner<UAllocatedArrayReading<Any>>()
+
+    fun <ArrayType> mkAllocatedArrayReading(
+        region: UAllocatedArrayMemoryRegion<USort>,
+        address: UHeapAddress,
+        index: USizeExpr,
+        arrayType: ArrayType,
+        elementSort: USort
+    ): UAllocatedArrayReading<ArrayType> = allocatedArrayReadingCache.createIfContextActive {
+        UAllocatedArrayReading(this, region, address, index, arrayType.cast(), elementSort)
+    }.cast()
+
+    private val inputArrayReadingCache = mkAstInterner<UInputArrayReading<Any>>()
+
+    fun <ArrayType> mkInputArrayReading(
+        region: UInputArrayMemoryRegion<USort>,
+        address: UHeapRef,
+        index: USizeExpr,
+        arrayType: ArrayType,
+        elementSort: USort
+    ): UInputArrayReading<ArrayType> = inputArrayReadingCache.createIfContextActive {
+        UInputArrayReading(this, region, address, index, arrayType.cast(), elementSort)
+    }.cast()
+
+    private val arrayLengthCache = mkAstInterner<UArrayLength<Any>>()
+
+    fun <ArrayType> mkArrayLength(
+        region: UArrayLengthMemoryRegion,
+        address: UHeapRef,
+        arrayType: ArrayType
+    ): UArrayLength<ArrayType> = arrayLengthCache.createIfContextActive {
+        UArrayLength(this, region, address, arrayType.cast())
+    }.cast()
+
+    private val indexedMethodReturnValueCache = mkAstInterner<UIndexedMethodReturnValue<Any>>()
+
+    fun <Method> mkIndexedMethodReturnValue(
+        method: Method,
+        callIndex: Int,
+        sort: USort
+    ): UIndexedMethodReturnValue<Method> = indexedMethodReturnValueCache.createIfContextActive {
+        UIndexedMethodReturnValue(this, method.cast(), callIndex, sort)
+    }.cast()
+
+    private val isExprCache = mkAstInterner<UIsExpr<Any>>()
+    fun <Type> mkIsExpr(
+        ref: UHeapRef, type: Type
+    ): UIsExpr<Type> = isExprCache.createIfContextActive {
+        UIsExpr(this, ref, type.cast())
+    }.cast()
+
+    fun <Sort : USort> mkDefault(sort: Sort): UExpr<Sort> =
+        when (sort) {
             is UAddressSort -> nullRef.asExpr(sort)
             else -> sort.sampleValue()
         }
 
     // TODO: delegate it to KSMT
     fun mkNotSimplified(expr: UBoolExpr) =
-        when(expr) {
+        when (expr) {
             is UNotExpr -> expr.arg
             else -> expr.ctx.mkNot(expr)
         }
+
+    // TODO remove it when we have KSMT 0.3.3 version
+    private inline fun <T> ensureContextActive(block: () -> T): T {
+        check(isActive) { "Context is not active" }
+        return block()
+    }
+
+    // TODO remove it when we have KSMT 0.3.3 version
+    private inline fun <T> AstInterner<T>.createIfContextActive(
+        builder: () -> T
+    ): T where T : KAst, T : KInternedObject = ensureContextActive {
+        intern(builder())
+    }
+
+    // TODO remove it when we have KSMT 0.3.3 version
+    private fun <T> mkAstInterner(): AstInterner<T> where T : KAst, T : KInternedObject =
+        org.ksmt.cache.mkAstInterner(operationMode, astManagementMode)
+
+
 }
 
 fun USort.defaultValue() =
-    when(ctx) {
+    when (ctx) {
         is UContext -> (ctx as UContext).mkDefault(this)
         else -> sampleValue()
     }

--- a/usvm-core/src/main/kotlin/org/usvm/Memory.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Memory.kt
@@ -89,13 +89,13 @@ open class UMemoryBase<Field, Type, Method>(
     override fun alloc(type: Type): UHeapRef {
         val address = heap.allocate()
         types.allocate(address, type)
-        return UConcreteHeapRef(address, ctx) // TODO: allocate all expr via UContext
+        return ctx.mkConcreteHeapRef(address)
     }
 
     override fun malloc(arrayType: Type, count: USizeExpr): UHeapRef {
         val address = heap.allocateArray(count)
         types.allocate(address, arrayType)
-        return UConcreteHeapRef(address, ctx) // TODO: allocate all expr via UContext
+        return ctx.mkConcreteHeapRef(address)
     }
 
     override fun memset(ref: UHeapRef, arrayType: Type, elementSort: USort, contents: Sequence<UExpr<USort>>) =

--- a/usvm-core/src/main/kotlin/org/usvm/Mocks.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Mocks.kt
@@ -28,7 +28,7 @@ class UIndexedMocker<Method>(
     override fun call(method: Method, args: Sequence<UExpr<USort>>, sort: USort): Pair<UMockSymbol, UMocker<Method>> {
         val currentClauses = clauses.getOrDefault(method, persistentListOf())
         val index = currentClauses.count()
-        val const = UIndexedMethodReturnValue(ctx, method, index, sort) // TODO: create expressions via ctx
+        val const = ctx.mkIndexedMethodReturnValue(method, index, sort)
         val updatedClauses = clauses.put(method, currentClauses.add(const))
         return Pair(const, UIndexedMocker(ctx, updatedClauses))
     }

--- a/usvm-core/src/main/kotlin/org/usvm/Stack.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Stack.kt
@@ -1,5 +1,6 @@
 package org.usvm
 
+import org.ksmt.expr.KExpr
 import org.ksmt.solver.KModel
 
 interface UStackEvaluator {
@@ -35,8 +36,8 @@ class UStack(private val ctx: UContext,
 
     fun peek() = stack.peek()
 
-    fun readRegister(index: Int, sort: USort) =
-        peek()[index] ?: URegisterReading(ctx, index, sort)
+    fun readRegister(index: Int, sort: USort): KExpr<USort> =
+        peek()[index] ?: ctx.mkRegisterReading(index, sort)
 
     fun writeRegister(index: Int, value: UExpr<USort>) {
         peek()[index] = value

--- a/usvm-core/src/main/kotlin/org/usvm/TypeStorage.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/TypeStorage.kt
@@ -79,7 +79,7 @@ class UTypeStorage<Type>(
                 @Suppress("UNUSED_VARIABLE")
                 val constraints = supertypes.getOrDefault(ref, persistentSetOf())
                 // TODO: check if we have simple contradiction here and return false if we do
-                return UIsExpr(ctx, ref, type) // TODO: create expressions via UContext
+                return ctx.mkIsExpr(ref, type)
             }
         }
     }

--- a/usvm-core/src/test/kotlin/UContextInterningTest.kt
+++ b/usvm-core/src/test/kotlin/UContextInterningTest.kt
@@ -1,0 +1,271 @@
+package org.usvm.tests
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.ksmt.utils.cast
+import org.usvm.UAllocatedArrayMemoryRegion
+import org.usvm.UAllocatedArrayReading
+import org.usvm.UArrayLength
+import org.usvm.UArrayLengthMemoryRegion
+import org.usvm.UBoolSort
+import org.usvm.UBv32Sort
+import org.usvm.UConcreteHeapRef
+import org.usvm.UContext
+import org.usvm.UExpr
+import org.usvm.UFieldReading
+import org.usvm.UIndexedMethodReturnValue
+import org.usvm.UInputArrayMemoryRegion
+import org.usvm.UInputArrayReading
+import org.usvm.UIsExpr
+import org.usvm.URegisterReading
+import org.usvm.USizeExpr
+import org.usvm.USort
+import org.usvm.UVectorMemoryRegion
+
+class UContextInterningTest {
+    private lateinit var context: UContext
+
+    @BeforeEach
+    fun initializeContext() {
+        context = UContext()
+    }
+
+    @Test
+    fun testConcreteHeapRefInterning() = with(context) {
+        val firstAddress = 1
+        val secondAddress = 2
+
+        val equal = List(10) { mkConcreteHeapRef(firstAddress) }
+
+        val createdWithoutContext = UConcreteHeapRef(this, firstAddress)
+        val distinct = listOf(
+            mkConcreteHeapRef(firstAddress),
+            mkConcreteHeapRef(secondAddress),
+            createdWithoutContext
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+    @Test
+    fun testRegisterReadingInterning() = with(context) {
+        val fstSort = bv16Sort
+        val sndSort = bv32Sort
+
+        val fstIndex = 1
+        val sndIndex = 2
+
+        val equal = List(10) { mkRegisterReading(fstIndex, fstSort) }
+
+        val createdWithoutContest = URegisterReading(context, fstIndex, fstSort)
+        val distinct = listOf(
+            mkRegisterReading(fstIndex, fstSort),
+            mkRegisterReading(fstIndex, sndSort),
+            mkRegisterReading(sndIndex, fstSort),
+            mkRegisterReading(sndIndex, sndSort),
+            createdWithoutContest
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+    @Test
+    fun testFieldReadingInterning() = with(context) {
+        // TODO replace after making `out` type in MemoryRegion
+        val fstRegion: UVectorMemoryRegion<USort> = mockk<UVectorMemoryRegion<UBv32Sort>>().cast()
+        val sndRegion: UVectorMemoryRegion<USort> = mockk<UVectorMemoryRegion<UBoolSort>>().cast()
+
+        every { fstRegion.sort } returns bv32Sort
+        every { sndRegion.sort } returns boolSort
+
+        val fstAddress = mkConcreteHeapRef(address = 1)
+        val sndAddress = mkConcreteHeapRef(address = 2)
+
+        val fstField = mockk<java.lang.reflect.Field>() // TODO replace with JaCoDB
+        val sndField = mockk<java.lang.reflect.Field>()
+
+        val equal = List(10) { mkFieldReading(fstRegion, fstAddress, fstField) }
+
+        val createdWithoutContext = UFieldReading(this, fstRegion, fstAddress, fstField)
+        val distinct = listOf(
+            mkFieldReading(fstRegion, fstAddress, fstField),
+            mkFieldReading(fstRegion, fstAddress, sndField),
+            mkFieldReading(fstRegion, sndAddress, fstField),
+            mkFieldReading(fstRegion, sndAddress, sndField),
+            mkFieldReading(sndRegion, fstAddress, fstField),
+            mkFieldReading(sndRegion, fstAddress, sndField),
+            mkFieldReading(sndRegion, sndAddress, fstField),
+            mkFieldReading(sndRegion, sndAddress, sndField),
+            createdWithoutContext
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+    @Test
+    fun testAllocatedArrayReadingInterning() = with(context) {
+        // TODO replace after making `out` type in regions
+        val fstRegion: UAllocatedArrayMemoryRegion<USort> = mockk<UAllocatedArrayMemoryRegion<UBv32Sort>>().cast()
+        val sndRegion: UAllocatedArrayMemoryRegion<USort> = mockk<UAllocatedArrayMemoryRegion<UBoolSort>>().cast()
+
+        every { fstRegion.sort } returns bv32Sort
+        every { sndRegion.sort } returns boolSort
+
+        val fstAddress = 1
+        val sndAddress = 2
+
+        val fstIndex = mockk<USizeExpr>()
+        val sndIndex = mockk<USizeExpr>()
+
+        val fstArrayType = mockk<java.lang.reflect.Field>() // TODO replace with JaCoDB
+        val sndArrayType = mockk<java.lang.reflect.Field>()
+
+        val fstElementSort = bv32Sort
+        val sndElementSort = boolSort
+
+        val equal = List(10) {
+            mkAllocatedArrayReading(fstRegion, fstAddress, fstIndex, fstArrayType, fstElementSort)
+        }
+
+        val createdWithoutContext =
+            UAllocatedArrayReading(this, fstRegion, fstAddress, fstIndex, fstArrayType, fstElementSort)
+        val distinct = listOf(
+            mkAllocatedArrayReading(fstRegion, fstAddress, fstIndex, fstArrayType, fstElementSort),
+            mkAllocatedArrayReading(sndRegion, fstAddress, fstIndex, fstArrayType, sndElementSort),
+            mkAllocatedArrayReading(fstRegion, sndAddress, fstIndex, fstArrayType, fstElementSort),
+            mkAllocatedArrayReading(fstRegion, fstAddress, sndIndex, fstArrayType, fstElementSort),
+            mkAllocatedArrayReading(fstRegion, fstAddress, fstIndex, sndArrayType, fstElementSort),
+            mkAllocatedArrayReading(sndRegion, sndAddress, sndIndex, sndArrayType, sndElementSort),
+            createdWithoutContext
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+    @Test
+    fun testInputArrayReadingInterning() = with(context) {
+        // TODO replace after making `out` type in regions
+        val fstRegion: UInputArrayMemoryRegion<USort> = mockk<UInputArrayMemoryRegion<UBv32Sort>>().cast()
+        val sndRegion: UInputArrayMemoryRegion<USort> = mockk<UInputArrayMemoryRegion<UBoolSort>>().cast()
+
+        every { fstRegion.sort } returns bv32Sort
+        every { sndRegion.sort } returns boolSort
+
+        val fstAddress = mkConcreteHeapRef(address = 1)
+        val sndAddress = mkConcreteHeapRef(address = 2)
+
+        val fstIndex = mockk<USizeExpr>()
+        val sndIndex = mockk<USizeExpr>()
+
+        val fstArrayType = mockk<java.lang.reflect.Field>() // TODO replace with JaCoDB
+        val sndArrayType = mockk<java.lang.reflect.Field>()
+
+        val fstElementSort = bv32Sort
+        val sndElementSort = boolSort
+
+        val equal = List(10) {
+            mkInputArrayReading(fstRegion, fstAddress, fstIndex, fstArrayType, fstElementSort)
+        }
+
+        val createdWithoutContext =
+            UInputArrayReading(this, fstRegion, fstAddress, fstIndex, fstArrayType, fstElementSort)
+        val distinct = listOf(
+            mkInputArrayReading(fstRegion, fstAddress, fstIndex, fstArrayType, fstElementSort),
+            mkInputArrayReading(sndRegion, fstAddress, fstIndex, fstArrayType, sndElementSort),
+            mkInputArrayReading(fstRegion, sndAddress, fstIndex, fstArrayType, fstElementSort),
+            mkInputArrayReading(fstRegion, fstAddress, sndIndex, fstArrayType, fstElementSort),
+            mkInputArrayReading(fstRegion, fstAddress, fstIndex, sndArrayType, fstElementSort),
+            mkInputArrayReading(sndRegion, sndAddress, sndIndex, sndArrayType, sndElementSort),
+            createdWithoutContext
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+
+    @Test
+    fun testArrayLengthInterning() = with(context) {
+        val fstRegion = mockk<UArrayLengthMemoryRegion>()
+        val sndRegion = mockk<UArrayLengthMemoryRegion>()
+
+        every { fstRegion.sort } returns sizeSort
+        every { sndRegion.sort } returns sizeSort
+
+        val fstAddress = mkConcreteHeapRef(address = 1)
+        val sndAddress = mkConcreteHeapRef(address = 2)
+
+        val fstArrayType = mockk<java.lang.reflect.Field>() // TODO replace with JaCoDB
+        val sndArrayType = mockk<java.lang.reflect.Field>()
+
+        val equal = List(10) { mkArrayLength(fstRegion, fstAddress, fstArrayType) }
+
+        val createdWithoutContext = UArrayLength(this, fstRegion, fstAddress, fstArrayType)
+        val distinct = listOf(
+            mkArrayLength(fstRegion, fstAddress, fstArrayType),
+            mkArrayLength(fstRegion, sndAddress, fstArrayType),
+            mkArrayLength(fstRegion, fstAddress, sndArrayType),
+            mkArrayLength(sndRegion, sndAddress, sndArrayType),
+            createdWithoutContext
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+    @Test
+    fun testIndexedMethodReturnValueInterning() = with(context) {
+        val fstMethod = mockk<java.lang.reflect.Method>()
+        val sndMethod = mockk<java.lang.reflect.Method>()
+
+        val fstCallIndex = 1
+        val sndCallIndex = 2
+
+        val fstSort = bv16Sort
+        val sndSort = bv32Sort
+
+        val equal = List(10) { mkIndexedMethodReturnValue(fstMethod, fstCallIndex, fstSort) }
+
+        val createdWithoutContext = UIndexedMethodReturnValue(this, fstMethod, fstCallIndex, fstSort)
+        val distinct = listOf(
+            mkIndexedMethodReturnValue(fstMethod, fstCallIndex, fstSort),
+            mkIndexedMethodReturnValue(fstMethod, sndCallIndex, fstSort),
+            mkIndexedMethodReturnValue(fstMethod, fstCallIndex, sndSort),
+            mkIndexedMethodReturnValue(sndMethod, sndCallIndex, sndSort),
+            createdWithoutContext
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+    @Test
+    fun testIsExprInterning() = with(context) {
+        val fstRef = mkConcreteHeapRef(address = 1)
+        val sndRef = mkConcreteHeapRef(address = 2)
+
+        val fstSort = bv16Sort // TODO replace with jacodb type
+        val sndSort = bv32Sort
+
+        val equal = List(10) { mkIsExpr(fstRef, fstSort) }
+
+        val createdWithoutContext = UIsExpr(this, fstRef, fstSort)
+        val distinct = listOf(
+            mkIsExpr(fstRef, fstSort),
+            mkIsExpr(fstRef, sndSort),
+            mkIsExpr(sndRef, sndSort),
+            createdWithoutContext
+        )
+
+        assert(compare(equal, distinct))
+    }
+
+    private fun compare(
+        equals: List<UExpr<out USort>>,
+        distinct: List<UExpr<out USort>>
+    ): Boolean {
+        val internedCorrectly = equals.all { it === equals.first() }
+        val distinctWorkCorrectly = distinct.distinct().size == distinct.size
+
+        return internedCorrectly && distinctWorkCorrectly
+    }
+}


### PR DESCRIPTION
Added interning for inheritors of `USymbol` and `UConcreteHeapRef` using KSMT's caches and renamed `input*` and `allocated*` instances into `symbolicAddr*` and `concreteAddr*` correspondingly. 