### PR TITLE
Add iterators for UMemoryUpdates

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/MemoryRegions.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/MemoryRegions.kt
@@ -5,6 +5,7 @@ import org.usvm.util.RegionTree
 import org.usvm.util.SetRegion
 import org.usvm.util.emptyRegionTree
 import java.util.LinkedList
+import java.util.NoSuchElementException
 
 //region Memory region
 
@@ -27,9 +28,12 @@ interface UUpdateNode<Key, ValueSort : USort> {
     /**
      * @see [UMemoryRegion.split]
      */
-    fun split(key: Key, predicate: (UExpr<ValueSort>) -> Boolean,
-              matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<ValueSort>>>,
-              guardBuilder: GuardBuilder): UUpdateNode<Key, ValueSort>?
+    fun split(
+        key: Key,
+        predicate: (UExpr<ValueSort>) -> Boolean,
+        matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<ValueSort>>>,
+        guardBuilder: GuardBuilder
+    ): UUpdateNode<Key, ValueSort>?
 
     /**
      * @return Value which has been written into the address [key] during this memory write operation.
@@ -70,9 +74,12 @@ interface UMemoryUpdates<Key, Sort : USort> : Sequence<UUpdateNode<Key, Sort>> {
     /**
      * @see [UMemoryRegion.split]
      */
-    fun split(key: Key, predicate: (UExpr<Sort>) -> Boolean,
-              matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
-              guardBuilder: GuardBuilder): UMemoryUpdates<Key, Sort>
+    fun split(
+        key: Key,
+        predicate: (UExpr<Sort>) -> Boolean,
+        matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
+        guardBuilder: GuardBuilder
+    ): UMemoryUpdates<Key, Sort>
 
     /**
      * @return Updates expressing copying the slice of [fromRegion] (see UMemoryRegion.copy)
@@ -97,29 +104,36 @@ data class UMemoryRegion<Key, Sort : USort>(
 ) {
     private fun read(key: Key, updates: UMemoryUpdates<Key, Sort>): UExpr<Sort> {
         val iterator = updates.iterator()
+
         val hasUpdates = iterator.hasNext()
-        if (!hasUpdates && defaultValue !== null) {
+        if (!hasUpdates && defaultValue != null) {
             // Reading from untouched array filled with defaultValue
             return defaultValue
-        } else {
-            if (hasUpdates) {
-                val entry = iterator.next()
-                if (entry.includesConcretely(key)) {
-                    // The last write has overwritten the key
-                    return entry.value(key)
-                }
-            }
-            val localizedRegion =
-                if (updates === this.updates) this
-                else UMemoryRegion(sort, updates, defaultValue, instantiator)
-            return instantiator(key, localizedRegion)
         }
+
+        if (hasUpdates) {
+            val entry = iterator.next()
+            if (entry.includesConcretely(key)) {
+                // The last write has overwritten the key
+                return entry.value(key)
+            }
+        }
+
+        val localizedRegion = if (updates === this.updates) {
+            this
+        } else {
+            UMemoryRegion(sort, updates, defaultValue, instantiator)
+        }
+
+        return instantiator(key, localizedRegion)
     }
 
     fun read(key: Key): UExpr<Sort> {
-        if (sort == sort.uctx.addressSort)
+        if (sort == sort.uctx.addressSort) {
             // Here we split concrete heap addresses from symbolic ones to optimize further memory operations.
             return splittingRead(key) { it is UConcreteHeapRef }
+        }
+
         val updates = updates.read(key)
         return read(key, updates)
     }
@@ -134,40 +148,47 @@ data class UMemoryRegion<Key, Sort : USort>(
      * These two expressions are semantically equivalent, but the second one 'splits' v out of the rest
      * memory updates.
      */
-    private fun splittingRead(key: Key, predicate: (UExpr<Sort>) -> Boolean): UExpr<Sort>
-    {
+    private fun splittingRead(key: Key, predicate: (UExpr<Sort>) -> Boolean): UExpr<Sort> {
         val ctx = sort.ctx
         val guardBuilder = GuardBuilder(ctx.trueExpr, ctx.trueExpr)
         val matchingWrites = LinkedList<Pair<UBoolExpr, UExpr<Sort>>>()
         val splittingUpdates = split(key, predicate, matchingWrites, guardBuilder).updates
-        if (matchingWrites.isEmpty())
+
+        if (matchingWrites.isEmpty()) {
             return instantiator(key, this)
+        }
+
         val reading = read(key, splittingUpdates)
         var iteAcc = reading
+
         for (write in matchingWrites) {
             iteAcc = ctx.mkIte(write.first, write.second, iteAcc)
         }
+
         return iteAcc
     }
 
     fun write(key: Key, value: UExpr<Sort>): UMemoryRegion<Key, Sort> {
         assert(value.sort == sort)
+
         val newUpdates = updates.write(key, value)
         return UMemoryRegion(sort, newUpdates, defaultValue, instantiator)
     }
 
-    internal fun split(key: Key, predicate: (UExpr<Sort>) -> Boolean,
-                       matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
-                       guardBuilder: GuardBuilder): UMemoryRegion<Key, Sort>
-    {
+    internal fun split(
+        key: Key, predicate: (UExpr<Sort>) -> Boolean,
+        matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
+        guardBuilder: GuardBuilder
+    ): UMemoryRegion<Key, Sort> {
         // TODO: either check in UMemoryRegion constructor that we do not construct memory region with
         //       non-null reference as default value, or implement splitting by default value.
-        assert(defaultValue === null || !predicate(defaultValue))
+        assert(defaultValue == null || !predicate(defaultValue))
+
         val count = matchingWrites.size
         val splittingUpdates = updates.read(key).split(key, predicate, matchingWrites, guardBuilder)
-        if (matchingWrites.size == count)
-            return this
-        return UMemoryRegion(sort, splittingUpdates, defaultValue, instantiator)
+        val sizeRemainedUnchanged = matchingWrites.size == count
+
+        return if (sizeRemainedUnchanged) this else UMemoryRegion(sort, splittingUpdates, defaultValue, instantiator)
     }
 
     /**
@@ -175,8 +196,14 @@ data class UMemoryRegion<Key, Sort : USort>(
      * with values from memory region [fromRegion] read from range
      * of addresses [[keyConverter] ([fromKey]) : [keyConverter] ([toKey])]
      */
-    fun copy(fromRegion: UMemoryRegion<Key, Sort>, fromKey: Key, toKey: Key, keyConverter: (Key) -> Key) =
-        UMemoryRegion(sort, updates.copy(fromRegion, fromKey, toKey, keyConverter), defaultValue, instantiator)
+    fun copy(
+        fromRegion: UMemoryRegion<Key, Sort>,
+        fromKey: Key, toKey: Key,
+        keyConverter: (Key) -> Key
+    ): UMemoryRegion<Key, Sort> {
+        val updatesCopy = updates.copy(fromRegion, fromKey, toKey, keyConverter)
+        return UMemoryRegion(sort, updatesCopy, defaultValue, instantiator)
+    }
 }
 
 class GuardBuilder(var matchingUpdatesGuard: UBoolExpr, var nonMatchingUpdatesGuard: UBoolExpr)
@@ -189,7 +216,8 @@ class GuardBuilder(var matchingUpdatesGuard: UBoolExpr, var nonMatchingUpdatesGu
  * Represents a single write of [value] into a memory address [key]
  */
 class UPinpointUpdateNode<Key, ValueSort : USort>(
-    private val key: Key, private val value: UExpr<ValueSort>,
+    val key: Key,
+    private val value: UExpr<ValueSort>,
     private val keyEqualityComparer: (Key, Key) -> UBoolExpr,
     override val guard: UBoolExpr = value.ctx.trueExpr
 ) : UUpdateNode<Key, ValueSort> {
@@ -199,33 +227,44 @@ class UPinpointUpdateNode<Key, ValueSort : USort>(
         guard.ctx.mkAnd(keyEqualityComparer(this.key, key), guard) // TODO: use simplifying and!
 
     override fun value(key: Key): UExpr<ValueSort> = this.value
-    override fun split(key: Key, predicate: (UExpr<ValueSort>) -> Boolean,
-                       matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<ValueSort>>>,
-                       guardBuilder: GuardBuilder): UUpdateNode<Key, ValueSort>?
-    {
+
+    override fun split(
+        key: Key,
+        predicate: (UExpr<ValueSort>) -> Boolean,
+        matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<ValueSort>>>,
+        guardBuilder: GuardBuilder
+    ): UUpdateNode<Key, ValueSort>? {
         val keyEq = keyEqualityComparer(key, this.key)
         val ctx = value.ctx
         val keyDiseq = ctx.mkNot(keyEq)
+
         if (predicate(value)) {
             val guard = ctx.mkAnd(guardBuilder.nonMatchingUpdatesGuard, keyEq)
             matchingWrites.add(Pair(guard, value))
             guardBuilder.matchingUpdatesGuard = ctx.mkAnd(guardBuilder.matchingUpdatesGuard, keyDiseq)
             return null
         }
+
         val hadNonMatchingUpdates = guardBuilder.nonMatchingUpdatesGuard != ctx.trueExpr
         guardBuilder.nonMatchingUpdatesGuard = ctx.mkAnd(guardBuilder.nonMatchingUpdatesGuard, ctx.mkNot(keyEq))
+
         return if (hadNonMatchingUpdates) this.guardWith(guardBuilder.matchingUpdatesGuard) else this
     }
 
     override fun guardWith(guard: UBoolExpr): UUpdateNode<Key, ValueSort> =
-        if (guard == guard.ctx.trueExpr) this
-        else
-            UPinpointUpdateNode(key, value, keyEqualityComparer, guard.ctx.mkAnd(this.guard, guard))
+        if (guard == guard.ctx.trueExpr) {
+            this
+        } else {
+            val guardExpr = guard.ctx.mkAnd(this.guard, guard)
+            UPinpointUpdateNode(key, value, keyEqualityComparer, guardExpr)
+        }
 
     override fun equals(other: Any?): Boolean =
         other is UPinpointUpdateNode<*, *> && this.key == other.key  // Ignores value
 
     override fun hashCode(): Int = key.hashCode()  // Ignores value
+
+    override fun toString(): String = "{$key <- $value}"
 }
 
 /**
@@ -234,7 +273,8 @@ class UPinpointUpdateNode<Key, ValueSort : USort>(
  * of addresses [[keyConverter] ([fromKey]) : [keyConverter] ([toKey])]
  */
 class URangedUpdateNode<Key, ValueSort : USort>(
-    private val fromKey: Key, private val toKey: Key,
+    val fromKey: Key,
+    val toKey: Key,
     private val region: UMemoryRegion<Key, ValueSort>,
     private val concreteComparer: (Key, Key) -> Boolean,
     private val symbolicComparer: (Key, Key) -> UBoolExpr,
@@ -248,32 +288,36 @@ class URangedUpdateNode<Key, ValueSort : USort>(
         val leftIsLefter = symbolicComparer(fromKey, key)
         val rightIsRighter = symbolicComparer(key, toKey)
         val ctx = leftIsLefter.ctx
+
         return ctx.mkAnd(leftIsLefter, rightIsRighter, guard) // TODO: use simplifying and!
     }
 
-    override fun value(key: Key): UExpr<ValueSort> =
-        region.read(keyConverter(key))
+    override fun value(key: Key): UExpr<ValueSort> = region.read(keyConverter(key))
 
     override fun guardWith(guard: UBoolExpr): UUpdateNode<Key, ValueSort> =
-        if (guard == guard.ctx.trueExpr) this
-        else
-            URangedUpdateNode(fromKey, toKey, region, concreteComparer, symbolicComparer, keyConverter,
-                guard.ctx.mkAnd(this.guard, guard))
+        if (guard == guard.ctx.trueExpr) {
+            this
+        } else {
+            val guardExpr = guard.ctx.mkAnd(this.guard, guard)
+            URangedUpdateNode(fromKey, toKey, region, concreteComparer, symbolicComparer, keyConverter, guardExpr)
+        }
 
     override fun equals(other: Any?): Boolean =
         other is URangedUpdateNode<*, *> && this.fromKey == other.fromKey && this.toKey == other.toKey  // Ignores update
 
     override fun hashCode(): Int = 31 * fromKey.hashCode() + toKey.hashCode()  // Ignores update
 
-    override fun split(key: Key, predicate: (UExpr<ValueSort>) -> Boolean,
-                       matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<ValueSort>>>,
-                       guardBuilder: GuardBuilder): UUpdateNode<Key, ValueSort>
-    {
+    override fun split(
+        key: Key, predicate: (UExpr<ValueSort>) -> Boolean,
+        matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<ValueSort>>>,
+        guardBuilder: GuardBuilder
+    ): UUpdateNode<Key, ValueSort> {
         val splittedRegion = region.split(key, predicate, matchingWrites, guardBuilder)
         if (splittedRegion === region) {
             return this
         }
-        return URangedUpdateNode(fromKey, toKey, splittedRegion, concreteComparer, symbolicComparer,keyConverter)
+
+        return URangedUpdateNode(fromKey, toKey, splittedRegion, concreteComparer, symbolicComparer, keyConverter)
     }
 }
 
@@ -282,31 +326,48 @@ class UEmptyUpdates<Key, Sort : USort>(
     private val concreteCmp: (Key, Key) -> Boolean,
     private val symbolicCmp: (Key, Key) -> UBoolExpr
 ) : UMemoryUpdates<Key, Sort> {
+    override fun read(key: Key): UMemoryUpdates<Key, Sort> = this
+
+    override fun write(key: Key, value: UExpr<Sort>): UMemoryUpdates<Key, Sort> =
+        UFlatUpdates(
+            UPinpointUpdateNode(key, value, symbolicEq),
+            next = null,
+            symbolicEq,
+            concreteCmp,
+            symbolicCmp
+        )
+
+    override fun guardedWrite(key: Key, value: UExpr<Sort>, guard: UBoolExpr): UMemoryUpdates<Key, Sort> =
+        UFlatUpdates(
+            UPinpointUpdateNode(key, value, symbolicEq, guard),
+            next = null,
+            symbolicEq,
+            concreteCmp,
+            symbolicCmp
+        )
+
+    override fun copy(fromRegion: UMemoryRegion<Key, Sort>, fromKey: Key, toKey: Key, keyConverter: (Key) -> Key) =
+        UFlatUpdates(
+            URangedUpdateNode(fromKey, toKey, fromRegion, concreteCmp, symbolicCmp, keyConverter),
+            next = null,
+            symbolicEq,
+            concreteCmp,
+            symbolicCmp
+        )
+
+    override fun split(
+        key: Key,
+        predicate: (UExpr<Sort>) -> Boolean,
+        matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
+        guardBuilder: GuardBuilder
+    ) = this
+
+    override fun iterator(): Iterator<UUpdateNode<Key, Sort>> = EmptyIterator()
+
     private class EmptyIterator<Key, Sort : USort> : Iterator<UUpdateNode<Key, Sort>> {
         override fun hasNext(): Boolean = false
         override fun next(): UUpdateNode<Key, Sort> = error("Advancing empty iterator")
     }
-
-    override fun read(key: Key): UMemoryUpdates<Key, Sort> = this
-
-    override fun write(key: Key, value: UExpr<Sort>): UMemoryUpdates<Key, Sort> =
-        UFlatUpdates(UPinpointUpdateNode(key, value, symbolicEq), null, symbolicEq, concreteCmp, symbolicCmp)
-
-    override fun guardedWrite(key: Key, value: UExpr<Sort>, guard: UBoolExpr): UMemoryUpdates<Key, Sort> =
-        UFlatUpdates(UPinpointUpdateNode(key, value, symbolicEq, guard), null, symbolicEq, concreteCmp, symbolicCmp)
-
-    override fun copy(fromRegion: UMemoryRegion<Key, Sort>, fromKey: Key, toKey: Key, keyConverter: (Key) -> Key) =
-        UFlatUpdates(
-            URangedUpdateNode(fromKey, toKey, fromRegion, concreteCmp, symbolicCmp, keyConverter), null,
-            symbolicEq, concreteCmp, symbolicCmp
-        )
-
-    override fun split(key: Key, predicate: (UExpr<Sort>) -> Boolean,
-                       matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
-                       guardBuilder: GuardBuilder)
-        = this
-
-    override fun iterator(): Iterator<UUpdateNode<Key, Sort>> = EmptyIterator()
 }
 
 data class UFlatUpdates<Key, Sort : USort>(
@@ -316,39 +377,84 @@ data class UFlatUpdates<Key, Sort : USort>(
     private val concreteCmp: (Key, Key) -> Boolean,
     private val symbolicCmp: (Key, Key) -> UBoolExpr
 ) : UMemoryUpdates<Key, Sort> {
-    private class UFlatUpdatesIterator<Key, Sort : USort>(private var current: UFlatUpdates<Key, Sort>?) :
-        Iterator<UUpdateNode<Key, Sort>> {
-        override fun hasNext(): Boolean = current === null
-        override fun next(): UUpdateNode<Key, Sort> = current!!.node
-    }
-
     override fun read(key: Key): UMemoryUpdates<Key, Sort> = this
 
     override fun write(key: Key, value: UExpr<Sort>): UMemoryUpdates<Key, Sort> =
-        UFlatUpdates(UPinpointUpdateNode(key, value, symbolicEq), this, symbolicEq, concreteCmp, symbolicCmp)
+        UFlatUpdates(
+            UPinpointUpdateNode(key, value, symbolicEq),
+            next = this,
+            symbolicEq,
+            concreteCmp,
+            symbolicCmp
+        )
 
     override fun guardedWrite(key: Key, value: UExpr<Sort>, guard: UBoolExpr): UMemoryUpdates<Key, Sort> =
-        UFlatUpdates(UPinpointUpdateNode(key, value, symbolicEq, guard), this, symbolicEq, concreteCmp, symbolicCmp)
+        UFlatUpdates(
+            UPinpointUpdateNode(key, value, symbolicEq, guard),
+            next = this,
+            symbolicEq,
+            concreteCmp,
+            symbolicCmp
+        )
 
     override fun copy(fromRegion: UMemoryRegion<Key, Sort>, fromKey: Key, toKey: Key, keyConverter: (Key) -> Key) =
         UFlatUpdates(
-            URangedUpdateNode(fromKey, toKey, fromRegion, concreteCmp, symbolicCmp, keyConverter), this,
-            symbolicEq, concreteCmp, symbolicCmp
+            URangedUpdateNode(fromKey, toKey, fromRegion, concreteCmp, symbolicCmp, keyConverter),
+            next = this,
+            symbolicEq,
+            concreteCmp,
+            symbolicCmp
         )
 
-    override fun split(key: Key, predicate: (UExpr<Sort>) -> Boolean,
-                       matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
-                       guardBuilder: GuardBuilder): UMemoryUpdates<Key, Sort> {
+    override fun split(
+        key: Key, predicate: (UExpr<Sort>) -> Boolean,
+        matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
+        guardBuilder: GuardBuilder
+    ): UMemoryUpdates<Key, Sort> {
         val splittingNode = node.split(key, predicate, matchingWrites, guardBuilder)
         val splittingNext = next?.split(key, predicate, matchingWrites, guardBuilder)
-        if (splittingNode === null)
+
+        if (splittingNode == null) {
             return splittingNext ?: UEmptyUpdates(symbolicEq, concreteCmp, symbolicCmp)
-        if (splittingNext === next)
+        }
+
+        if (splittingNext === next) {
             return this
+        }
+
         return UFlatUpdates(splittingNode, splittingNext, symbolicEq, concreteCmp, symbolicCmp)
     }
 
-    override fun iterator(): Iterator<UUpdateNode<Key, Sort>> = UFlatUpdatesIterator(this)
+    /**
+     * Returns updates in the FIFO order: the iterator emits updates from the oldest updates to the most recent one.
+     * It means that the `initialNode` from the [UFlatUpdatesIterator] will be returned as the last element.
+     */
+    override fun iterator(): Iterator<UUpdateNode<Key, Sort>> = UFlatUpdatesIterator(initialNode = this)
+
+    private class UFlatUpdatesIterator<Key, Sort : USort>(
+        initialNode: UFlatUpdates<Key, Sort>,
+    ) : Iterator<UUpdateNode<Key, Sort>> {
+        private val iterator: Iterator<UUpdateNode<Key, Sort>>
+
+        init {
+            val elements = mutableListOf<UUpdateNode<Key, Sort>>()
+            var current: UFlatUpdates<Key, Sort>? = initialNode
+
+            // Traverse over linked list of updates nodes and extract them into an array list
+            while (current != null) {
+                elements += current.node
+                // We can safely apply `as?` since we are interested only in non-empty updates
+                // and there are no `treeUpdates` as a `next` element of the `UFlatUpdates`
+                current = current.next as? UFlatUpdates<Key, Sort>
+            }
+
+            iterator = elements.asReversed().iterator()
+        }
+
+        override fun hasNext(): Boolean = iterator.hasNext()
+
+        override fun next(): UUpdateNode<Key, Sort> = iterator.next()
+    }
 }
 
 //endregion
@@ -366,41 +472,114 @@ data class UTreeUpdates<Key, Reg : Region<Reg>, Sort : USort>(
     override fun read(key: Key): UTreeUpdates<Key, Reg, Sort> {
         val reg = keyToRegion(key)
         val updates = updates.localize(reg)
-        if (updates === this.updates)
+        if (updates === this.updates) {
             return this
+        }
+
         return UTreeUpdates(updates, keyToRegion, keyRangeToRegion, symbolicEq, concreteCmp, symbolicCmp)
     }
 
     override fun write(key: Key, value: UExpr<Sort>): UTreeUpdates<Key, Reg, Sort> {
         val update = UPinpointUpdateNode(key, value, symbolicEq)
-        val newUpdates = updates.write(keyToRegion(key), update)
+        val newUpdates = updates.write(keyToRegion(key), update, keyFilter = { it == key })
+
         return UTreeUpdates(newUpdates, keyToRegion, keyRangeToRegion, symbolicEq, concreteCmp, symbolicCmp)
     }
 
     override fun guardedWrite(key: Key, value: UExpr<Sort>, guard: UBoolExpr): UTreeUpdates<Key, Reg, Sort> {
         val update = UPinpointUpdateNode(key, value, symbolicEq, guard)
-        val newUpdates = updates.write(keyToRegion(key), update)
+        val newUpdates = updates.write(keyToRegion(key), update, keyFilter = { it == key })
+
         return UTreeUpdates(newUpdates, keyToRegion, keyRangeToRegion, symbolicEq, concreteCmp, symbolicCmp)
     }
 
-    override fun copy(fromRegion: UMemoryRegion<Key, Sort>, fromKey: Key, toKey: Key, keyConverter: (Key) -> Key)
-            : UTreeUpdates<Key, Reg, Sort> {
+    override fun copy(
+        fromRegion: UMemoryRegion<Key, Sort>,
+        fromKey: Key,
+        toKey: Key,
+        keyConverter: (Key) -> Key
+    ): UTreeUpdates<Key, Reg, Sort> {
         val region = keyRangeToRegion(fromKey, toKey)
         val update = URangedUpdateNode(fromKey, toKey, fromRegion, concreteCmp, symbolicCmp, keyConverter)
-        val newUpdates = updates.write(region, update)
+        val newUpdates = updates.write(region, update, keyFilter = { it == update })
+
         return UTreeUpdates(newUpdates, keyToRegion, keyRangeToRegion, symbolicEq, concreteCmp, symbolicCmp)
     }
 
-    override fun split(key: Key, predicate: (UExpr<Sort>) -> Boolean,
+    override fun split(
+        key: Key,
+        predicate: (UExpr<Sort>) -> Boolean,
         matchingWrites: LinkedList<Pair<UBoolExpr, UExpr<Sort>>>,
         guardBuilder: GuardBuilder
     ): UMemoryUpdates<Key, Sort> {
         TODO("Not yet implemented")
     }
 
-    override fun iterator(): Iterator<UUpdateNode<Key, Sort>> {
-        TODO("Implement tree iterator in RegionTree")
+    /**
+     * Returns updates in the FIFO order: the iterator emits updates from the oldest updates to the most recent one.
+     * Note that if some key in the tree is presented in more than one node, it will be returned exactly ones.
+     */
+    override fun iterator(): Iterator<UUpdateNode<Key, Sort>> = TreeIterator(updates.iterator())
+
+    override fun toString(): String {
+        return "$updates"
     }
+
+    private inner class TreeIterator(
+        private val treeUpdatesIterator: Iterator<Pair<UUpdateNode<Key, Sort>, Reg>>
+    ) : Iterator<UUpdateNode<Key, Sort>> {
+        // A set of values we already emitted by this iterator.
+        // Note that it contains ONLY elements that have duplicates by key in the RegionTree.
+        private val emittedUpdates = hashSetOf<UUpdateNode<Key, Sort>>()
+
+        // We can return just `hasNext` value without checking for duplicates since
+        // the last node contains a unique key (because non-unique keys might occur only
+        // as a result of splitting because of some other write operation).
+        override fun hasNext(): Boolean = treeUpdatesIterator.hasNext()
+
+        override fun next(): UUpdateNode<Key, Sort> {
+            while (treeUpdatesIterator.hasNext()) {
+                val (update, region) = treeUpdatesIterator.next()
+
+                // To check, whether we have a duplicate for a particular key,
+                // we have to check if an initial region (by USVM estimation) is equal
+                // to the one stored in the current node.
+                val initialRegion = when (update) {
+                    is UPinpointUpdateNode<Key, Sort> -> keyToRegion(update.key)
+                    is URangedUpdateNode<Key, Sort> -> keyRangeToRegion(update.fromKey, update.toKey)
+                    else -> error("An unsupported type of UpdateNode is provided: ${update::class}")
+                }
+                val wasCloned = initialRegion != region
+
+                // If a region from the current node is equal to the initial region,
+                // it means that there were no write operation that caused nodes split,
+                // and the node doesn't have `duplicates` in the tree.
+                if (!wasCloned) {
+                    return update
+                }
+
+                // If there are duplicates, we have to emit exactly one of them -- the first we encountered.
+                // Otherwise, we might have a problem. For example, we write by key `j` that belongs to {1, 2} region.
+                // Then we wrote 1 with region {1} and 2 with region {2}. We have the following tree:
+                // ({1} -> (1, {1} -> j), {2} -> (2, {2} -> j)). Without any additional actions, its iterator
+                // will emit the following values: (j, 1, j, 2). We don't want to deal with their region
+                // during encoding, so, we want to go through this sequence and apply updates, but we cannot do it.
+                // We write by key `j`, then by `1`, then again by `j`, which overwrites a more recent update
+                // in the region {1} and causes the following memory: [j, 2] instead of [1, 2].
+                if (update in emittedUpdates) {
+                    continue
+                }
+
+                emittedUpdates += update
+
+                return update
+            }
+
+            throw NoSuchElementException()
+        }
+    }
+
+
 }
 
 //endregion
@@ -442,10 +621,8 @@ fun refIndexCmpSymbolic(idx1: USymbolicArrayIndex, idx2: USymbolicArrayIndex): U
 fun refIndexCmpConcrete(idx1: USymbolicArrayIndex, idx2: USymbolicArrayIndex): Boolean =
     idx1.first == idx2.first && indexLeConcrete(idx1.second, idx2.second)
 
-
 // TODO: change it to intervals region
 typealias UArrayIndexRegion = SetRegion<UIndexType>
-
 
 fun indexRegion(idx: USizeExpr): UArrayIndexRegion =
     when (idx) {
@@ -465,8 +642,10 @@ fun indexRangeRegion(idx1: USizeExpr, idx2: USizeExpr): UArrayIndexRegion =
     }
 
 fun refIndexRegion(idx: USymbolicArrayIndex): UArrayIndexRegion = indexRegion(idx.second)
-fun refIndexRangeRegion(idx1: USymbolicArrayIndex, idx2: USymbolicArrayIndex): UArrayIndexRegion =
-    indexRangeRegion(idx1.second, idx2.second)
+fun refIndexRangeRegion(
+    idx1: USymbolicArrayIndex,
+    idx2: USymbolicArrayIndex
+): UArrayIndexRegion = indexRangeRegion(idx1.second, idx2.second)
 
 typealias UVectorMemoryRegion<Sort> = UMemoryRegion<UHeapRef, Sort>
 typealias UAllocatedArrayMemoryRegion<Sort> = UMemoryRegion<USizeExpr, Sort>
@@ -477,20 +656,19 @@ fun <Sort : USort> emptyFlatRegion(
     sort: Sort,
     defaultValue: UExpr<Sort>?,
     instantiator: UInstantiator<UHeapRef, Sort>
-) =
-    UMemoryRegion(
-        sort,
-        UEmptyUpdates(::heapRefEq, ::heapRefCmpConcrete, ::heapRefCmpSymbolic),
-        defaultValue,
-        instantiator
-    )
+) = UMemoryRegion(
+    sort,
+    UEmptyUpdates(::heapRefEq, ::heapRefCmpConcrete, ::heapRefCmpSymbolic),
+    defaultValue,
+    instantiator
+)
 
 fun <Sort : USort> emptyAllocatedArrayRegion(
     sort: Sort,
     instantiator: UInstantiator<USizeExpr, Sort>
 ): UAllocatedArrayMemoryRegion<Sort> {
     val updates = UTreeUpdates<USizeExpr, UArrayIndexRegion, Sort>(
-        emptyRegionTree(),
+        updates = emptyRegionTree(),
         ::indexRegion, ::indexRangeRegion, ::indexEq, ::indexLeConcrete, ::indexLeSymbolic
     )
     return UMemoryRegion(sort, updates, sort.uctx.mkDefault(sort), instantiator)
@@ -501,7 +679,7 @@ fun <Sort : USort> emptyInputArrayRegion(
     instantiator: UInstantiator<USymbolicArrayIndex, Sort>
 ): UInputArrayMemoryRegion<Sort> {
     val updates = UTreeUpdates<USymbolicArrayIndex, UArrayIndexRegion, Sort>(
-        emptyRegionTree(),
+        updates = emptyRegionTree(),
         ::refIndexRegion, ::refIndexRangeRegion, ::refIndexEq, ::refIndexCmpConcrete, ::refIndexCmpSymbolic
     )
     return UMemoryRegion(sort, updates, null, instantiator)
@@ -510,7 +688,7 @@ fun <Sort : USort> emptyInputArrayRegion(
 fun emptyArrayLengthRegion(ctx: UContext, instantiator: UInstantiator<UHeapRef, USizeSort>): UArrayLengthMemoryRegion =
     UMemoryRegion(
         ctx.sizeSort, UEmptyUpdates(::heapRefEq, ::heapRefCmpConcrete, ::heapRefCmpSymbolic),
-        null, instantiator
+        defaultValue = null, instantiator
     )
 
 //endregion

--- a/usvm-core/src/test/kotlin/org/usvm/UpdatesIteratorTest.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/UpdatesIteratorTest.kt
@@ -1,0 +1,87 @@
+package org.usvm
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.usvm.util.SetRegion
+import org.usvm.util.emptyRegionTree
+import java.lang.UnsupportedOperationException
+import kotlin.test.assertTrue
+
+class UpdatesIteratorTest {
+    @Test
+    fun testTreeRegionUpdates() {
+        with(UContext()) {
+            val treeUpdates = UTreeUpdates<Int, SetRegion<Int>, UBv32Sort>(
+                emptyRegionTree(),
+                { key ->
+                    if (key != 10) {
+                        SetRegion.singleton(key)
+                    } else {
+                        SetRegion.ofSet(1, 2, 3)
+                    }
+                },
+                { _, _ -> throw UnsupportedOperationException() },
+                { k1, k2 -> mkEq(k1.toBv(), k2.toBv()) },
+                { k1, k2 -> k1 == k2 },
+                { _, _ -> throw UnsupportedOperationException() }
+            ).write(10, 10.toBv())
+                .write(1, 1.toBv())
+                .write(2, 2.toBv())
+                .write(3, 3.toBv())
+
+            val iterator = treeUpdates.iterator()
+            checkResult(iterator)
+        }
+    }
+
+    @Test
+    fun testFlatUpdatesIterator() = with(UContext()) {
+        val firstUpdateNode = UPinpointUpdateNode(
+            key = 10,
+            value = 10.toBv(),
+            keyEqualityComparer = { k1, k2 -> mkEq(k1.toBv(), k2.toBv()) }
+        )
+
+        val flatUpdates = UFlatUpdates(
+            node = firstUpdateNode,
+            next = null,
+            { _, _ -> throw NotImplementedError() },
+            { _, _ -> throw NotImplementedError() },
+            { _, _ -> throw NotImplementedError() }
+        ).write(key = 1, value = 1.toBv())
+            .write(key = 2, value = 2.toBv())
+            .write(key = 3, value = 3.toBv())
+
+        val iterator = flatUpdates.iterator()
+        checkResult(iterator)
+    }
+
+    private fun <Key, ValueSort : USort> UContext.checkResult(
+        iterator: Iterator<UUpdateNode<Key, ValueSort>>
+    ) {
+        val elements = mutableListOf<UUpdateNode<Key, ValueSort>>()
+
+        while (iterator.hasNext()) {
+            elements += iterator.next()
+        }
+
+        assertThrows<NoSuchElementException> { iterator.next() }
+
+        val expectedValues = listOf(
+            10 to 10.toBv(),
+            1 to 1.toBv(),
+            2 to 2.toBv(),
+            3 to 3.toBv()
+        )
+
+        assertTrue { elements.size == expectedValues.size }
+
+        elements.zip(expectedValues).forEach { (pinpointUpdate, expectedKeyWithValue) ->
+            val key = (pinpointUpdate as UPinpointUpdateNode<Key, ValueSort>).key
+            val value = pinpointUpdate.value(key)
+
+            assertTrue { key == expectedKeyWithValue.first && value == expectedKeyWithValue.second }
+        }
+    }
+
+}

--- a/usvm-util/src/main/kotlin/org/usvm/util/RegionTree.kt
+++ b/usvm-util/src/main/kotlin/org/usvm/util/RegionTree.kt
@@ -1,95 +1,257 @@
 package org.usvm.util
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentHashMapOf
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toPersistentMap
+import java.util.NoSuchElementException
 
 /**
- * Region tree is a data structures storing collection of keys by abstract regions.
+ * Region tree is a data structure storing collection of keys by abstract regions.
  * It maintains the following two invariants:
- * (1) all sibling regions are pairwise disjoint
- * (2) all child regions are included into parent region
+ * * (1) all sibling regions are pairwise disjoint;
+ * * (2) all child regions are included into parent region.
  */
-class RegionTree<Key, Reg>(val entries: PersistentMap<Reg, Pair<Key, RegionTree<Key, Reg>>>)
-        where Reg: Region<Reg>
-{
-    val isEmpty = entries.isEmpty()
+class RegionTree<Key, Reg>(
+    val entries: PersistentMap<Reg, Pair<Key, RegionTree<Key, Reg>>>
+) : Iterable<Pair<Key, Reg>> where Reg : Region<Reg> {
+    @Suppress("MemberVisibilityCanBePrivate")
+    val isEmpty: Boolean get() = entries.isEmpty()
 
     /**
-     * Splits region tree into two trees: completely covered by [region] and disjoint with [region].
-     * Filters out nodes for which [filter] returns true.
+     * Splits the region tree into two trees: completely covered by the [region] and disjoint with it.
+     *
+     * [keyFilter] is an arbitrary predicate suitable to filter out nodes from the results of the function.
+     * Examples:
+     * * `{ it != 10 }` removes all the nodes with `key` equal to 10
+     * * `{ false }` doesn't remove anything
      */
-    private fun splitRecursively(region : Reg, filter: (Key) -> Boolean):  Pair<RegionTree<Key, Reg>, RegionTree<Key, Reg>>
-    {
-        if (isEmpty)
-            return Pair(this, this)
-        val entry = entries.get(region)
-        if (entry === null) {
-            // No such region. Dot it slow way: iterate all entries, group them into:
-            // (1) included by [region], (2) disjoint with [region], (3) partially intersected with [region].
-            // For nodes in group (3), repeat process recursively.
-            val included = mutableListOf<Pair<Reg, Pair<Key, RegionTree<Key, Reg>>>>()
-            val disjoint = mutableListOf<Pair<Reg, Pair<Key, RegionTree<Key, Reg>>>>()
-            val intersected = mutableListOf<Pair<Reg, Pair<Key, RegionTree<Key, Reg>>>>()
-            val groups = mutableMapOf(
-                Pair(Pair(RegionComparisonResult.INCLUDES, true), included),
-                Pair(Pair(RegionComparisonResult.DISJOINT, true), disjoint),
-                Pair(Pair(RegionComparisonResult.INTERSECTS, true), intersected)
-            )
-            entries.entries.groupByTo(groups, {
-                if (filter(it.value.first)) Pair(RegionComparisonResult.INCLUDES, false)
-                else Pair(region.compare(it.key), true)}, { Pair(it.key, it.value) })
-            var includedMap = persistentHashMapOf(*included.toTypedArray())
-            var disjointMap = persistentHashMapOf(*disjoint.toTypedArray())
-            intersected.forEach {
-                val (splitIncluded, splitDisjoint) = it.second.second.splitRecursively(region, filter)
-                val includedReg = it.first.intersect(region)
-                val disjointReg = it.first.subtract(region)
-                includedMap = includedMap.put(includedReg, Pair(it.second.first, splitIncluded))
-                disjointMap = disjointMap.put(disjointReg, Pair(it.second.first, splitDisjoint))
-            }
-            return Pair(RegionTree(includedMap), RegionTree(disjointMap))
-        } else {
-            // If we have precisely such region in tree, then all its siblings are disjoint by invariant (1).
-            // So just return (node storing the region, rest of its siblings)
-            val inside = if (filter(entry.first)) persistentHashMapOf() else persistentHashMapOf(Pair(region, entry))
-            val outside = entries.remove(region)
-            return Pair(RegionTree(inside), RegionTree(outside))
+    private fun splitRecursively(
+        region: Reg,
+        keyFilter: (Key) -> Boolean
+    ): RecursiveSplitResult {
+        if (isEmpty) {
+            return RecursiveSplitResult(completelyCoveredRegionTree = this, disjointRegionTree = this)
         }
+
+        val entry = entries[region]
+
+        // If we have precisely such region in the tree, then all its siblings are disjoint by invariant (1).
+        // So just return a `Pair(node storing the region, rest of its siblings)`
+        if (entry != null) {
+            val key = entry.first
+            // IMPORTANT: usage of linked versions of maps is mandatory here, since
+            // it is required for correct order of keys returned by `iterator.next()` method
+            val inside = if (keyFilter(key)) persistentMapOf() else persistentMapOf(region to entry)
+            val outside = entries.remove(region)
+
+            val completelyCoveredRegionTree = RegionTree(inside)
+            val disjointRegionTree = RegionTree(outside)
+
+            return RecursiveSplitResult(completelyCoveredRegionTree, disjointRegionTree)
+        }
+
+        // Such region doesn't exist. Do it slow way: iterate all the entries, group them into:
+        // (1) included by the [region],
+        // (2) disjoint with the [region],
+        // (3) partially intersected with the [region].
+
+        // IMPORTANT: usage of linked versions of maps is mandatory here, since
+        // it is required for correct order of keys returned by `iterator.next()` method
+        // We have to support the following order: assume that we had entries [e0, e1, e2, e3, e4]
+        // and a write operation into a region R that is a subregion of `e1` and `e3`, and covers e2 completely.
+        // The correct order of the result is:\
+        // included = [R ∩ e1, e2, R ∩ e3], disjoint = [e0, e1\R, e3\R, e4]
+        // That allows us to move recently updates region to the right side of the `entries` map and
+        // leave the oldest ones in the left part of it.
+        val included = mutableMapOf<Reg, Pair<Key, RegionTree<Key, Reg>>>()
+        val disjoint = mutableMapOf<Reg, Pair<Key, RegionTree<Key, Reg>>>()
+
+        entries.entries.forEach { (nodeRegion, keyWithRegionTree) ->
+            if (keyFilter(keyWithRegionTree.first)) {
+                // If we want to filter a region associated with the [key],
+                // we can simply do not add it to the `included` map result
+                return@forEach
+            } else {
+                when (region.compare(nodeRegion)) {
+                    RegionComparisonResult.INCLUDES -> included += nodeRegion to keyWithRegionTree
+                    RegionComparisonResult.DISJOINT -> disjoint += nodeRegion to keyWithRegionTree
+                    // For nodes with intersection, repeat process recursively.
+                    RegionComparisonResult.INTERSECTS -> {
+                        val (key, childRegionTree) = keyWithRegionTree
+                        val (splitIncluded, splitDisjoint) = childRegionTree.splitRecursively(region, keyFilter)
+
+                        val includedReg = nodeRegion.intersect(region)
+                        val disjointReg = nodeRegion.subtract(region)
+
+                        included[includedReg] = key to splitIncluded
+                        disjoint[disjointReg] = key to splitDisjoint
+                    }
+                }
+            }
+        }
+
+        // IMPORTANT: usage of linked versions of maps is mandatory here, since
+        // it is required for correct order of keys returned by `iterator.next()` method
+        val includedRegionTree = CompletelyCoveredRegionTree(included.toPersistentMap())
+        val disjointRegionTree = DisjointRegionTree(disjoint.toPersistentMap())
+
+        return RecursiveSplitResult(includedRegionTree, disjointRegionTree)
     }
 
     /**
-     * Returns subtree completely included into [region]
+     * Returns a subtree completely included into the [region].
      */
-    fun localize(region: Reg): RegionTree<Key, Reg> = splitRecursively(region) { false }.first
+    fun localize(region: Reg): RegionTree<Key, Reg> =
+        splitRecursively(region, keyFilter = { false }).completelyCoveredRegionTree
 
     /**
-     * Places ([region], [key]) into the tree, preserving its invariants
+     * Places a Pair([region], [key]) into the tree, preserving its invariants.
+     *
+     * [keyFilter] is a predicate suitable to filter out particular nodes if their `key` satisfies it.
+     * Examples:
+     * * `{ false }` doesn't filter anything
+     * * `{ it != key }` writes into a tree and restrict for it to contain non-unique keys.
+     *   Suitable for deduplication.
      */
-    fun write(region: Reg, key: Key): RegionTree<Key, Reg> {
-        val (included, disjoint) = splitRecursively(region) {key == it}
-        return RegionTree(disjoint.entries.put(region, Pair(key, included)))
+    fun write(region: Reg, key: Key, keyFilter: (Key) -> Boolean = { false }): RegionTree<Key, Reg> {
+        val (included, disjoint) = splitRecursively(region, keyFilter)
+        // A new node for a tree we construct accordingly to the (2) invariant.
+        val value = key to included
+
+        // Construct entries accordingly to the (1) invariant.
+        val disjointEntries = disjoint.entries.put(region, value)
+
+        return RegionTree(disjointEntries)
     }
 
     // TODO: add collection operations, like map, fold, filter, flatten, etc...
 
     private fun checkInvariantRecursively(parentRegion: Reg?): Boolean {
         // Invariant (2): all child regions are included into parent region
-        val invariant2 = parentRegion === null || entries.entries.all {parentRegion.compare(it.key) == RegionComparisonResult.INCLUDES}
-        return invariant2 &&
-                entries.entries.all {entry ->
-                    //  Invariant (1): all sibling regions are pairwise disjoint
-                    val invariant1 = entries.entries.all {
-                            other -> other.key === entry.key ||
-                            entry.key.compare(other.key) == RegionComparisonResult.DISJOINT
-                    }
-                    return invariant1 && entry.value.second.checkInvariantRecursively(entry.key)
+        val secondInvariant = parentRegion == null || entries.entries.all { (key, _) ->
+            parentRegion.compare(key) == RegionComparisonResult.INCLUDES
+        }
+
+        val checkInvariantRecursively = {
+            entries.entries.all { (entryKey, value) ->
+                // Invariant (1): all sibling regions are pairwise disjoint
+                val firstInvariant = entries.entries.all { other ->
+                    val otherKey = other.key
+                    otherKey === entryKey || entryKey.compare(otherKey) == RegionComparisonResult.DISJOINT
                 }
+
+                firstInvariant && value.second.checkInvariantRecursively(entryKey)
+            }
+        }
+
+        return secondInvariant && checkInvariantRecursively()
     }
 
     fun checkInvariant() {
-        if (!checkInvariantRecursively(null))
-            throw Exception("The invariant of region tree is violated!")
+        if (!checkInvariantRecursively(parentRegion = null)) {
+            error("The invariant of region tree is violated!")
+        }
+    }
+
+    /**
+     * Returns an iterator that returns topologically sorted elements.
+     * Note that elements from the same level will be processed in order from the
+     * oldest entry to the most recently updated one.
+     */
+    override fun iterator(): Iterator<Pair<Key, Reg>> = TheLeftestTopSortIterator(entries.iterator())
+
+    override fun toString(): String = if (isEmpty) "emptyTree" else toString(balance = 0)
+
+    private fun toString(balance: Int): String =
+        entries.entries.joinToString(separator = System.lineSeparator()) {
+            val subtree = it.value.second
+            val region = it.key
+            val key = it.value.first
+            val indent = "\t".repeat(balance)
+
+            val subtreeString = if (subtree.isEmpty) {
+                "\t" + indent + "emptyTree"
+            } else {
+                subtree.toString(balance + 1)
+            }
+
+            indent + "$region -> $key:${System.lineSeparator()}$subtreeString"
+        }
+
+    /**
+     * [entriesIterators] should be considered as a recursion stack where
+     * the last element is the deepest one in the branch we explore.
+     */
+    private inner class TheLeftestTopSortIterator private constructor(
+        private val entriesIterators: MutableList<RegionTreeEntryIterator<Key, Reg>>,
+    ) : Iterator<Pair<Key, Reg>> {
+        // A stack of elements we should emit after we process all their children.
+        // We cannot use for it corresponding iterators since every value from an
+        // iterator can be retrieved only once, but we already got it when we discovered the previous layer.
+        private val nodes: MutableList<RegionTreeMapEntry<Key, Reg>> = mutableListOf()
+
+        constructor(iterator: RegionTreeEntryIterator<Key, Reg>) : this(mutableListOf(iterator))
+
+        override fun hasNext(): Boolean {
+            while (entriesIterators.isNotEmpty()) {
+                val currentIterator = entriesIterators.last()
+
+                if (!currentIterator.hasNext()) {
+                    // We have nodes in the processing stack that we didn't emit yet
+                    return nodes.isNotEmpty()
+                }
+
+                // We have elements to process inside the currentIterator
+                return true
+            }
+
+            // Both iterators and nodes stacks are empty.
+            return false
+        }
+
+        override fun next(): Pair<Key, Reg> {
+            while (entriesIterators.isNotEmpty()) {
+                val currentIterator = entriesIterators.last()
+
+                // We reached an end of the current layer in the tree, go back to the previous one
+                if (!currentIterator.hasNext()) {
+                    entriesIterators.removeLast()
+                    // We processed all the children, now we can emit their parent
+                    return nodes.removeLast().let { it.value.first to it.key }
+                }
+
+                // Take the next element on the current layer
+                val entry = currentIterator.next()
+                val keyWithRegionTree = entry.value
+                val regionTree = keyWithRegionTree.second
+
+                // If it is a leaf, it is the answer, return it
+                if (regionTree.isEmpty) {
+                    return entry.value.first to entry.key
+                }
+
+                // Otherwise, add it in nodes list and an iterator for its children in the stack
+                nodes += entry
+                entriesIterators += regionTree.entries.iterator()
+            }
+
+            // That means that there are no unprocessed nodes in the tree
+            throw NoSuchElementException()
+        }
+    }
+
+    private inner class RecursiveSplitResult(
+        val completelyCoveredRegionTree: CompletelyCoveredRegionTree<Key, Reg>,
+        val disjointRegionTree: DisjointRegionTree<Key, Reg>
+    ) {
+        operator fun component1(): RegionTree<Key, Reg> = completelyCoveredRegionTree
+        operator fun component2(): RegionTree<Key, Reg> = disjointRegionTree
     }
 }
 
-fun <Key, Reg: Region<Reg>> emptyRegionTree() = RegionTree<Key, Reg>(persistentHashMapOf())
+private typealias DisjointRegionTree<Key, Reg> = RegionTree<Key, Reg>
+private typealias CompletelyCoveredRegionTree<Key, Reg> = RegionTree<Key, Reg>
+private typealias RegionTreeMapEntry<Key, Reg> = Map.Entry<Reg, Pair<Key, RegionTree<Key, Reg>>>
+private typealias RegionTreeEntryIterator<Key, Reg> = Iterator<RegionTreeMapEntry<Key, Reg>>
+
+fun <Key, Reg : Region<Reg>> emptyRegionTree() = RegionTree<Key, Reg>(persistentMapOf())

--- a/usvm-util/src/test/kotlin/org/usvm/test/RegionTreeIteratorTest.kt
+++ b/usvm-util/src/test/kotlin/org/usvm/test/RegionTreeIteratorTest.kt
@@ -1,0 +1,160 @@
+package org.usvm.test
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.usvm.util.RegionTree
+import org.usvm.util.SetRegion
+import org.usvm.util.emptyRegionTree
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RegionTreeIteratorTest {
+    @Test
+    fun testSimpleRecursiveIterator() {
+        val region = SetRegion.ofSet(0, 1, 2, 3, 4, 5)
+        val tree = emptyRegionTree<Int, SetRegion<Int>>()
+            .write(region, 10)                // {0..5} -> 10
+            .write(SetRegion.singleton(3), 5) // {0..2, 4, 5} -> 10, {3} -> (5, {3} -> 10)
+
+        val treeIterator = tree.iterator()
+
+        val (firstKey, firstRegion) = treeIterator.next()   // {0..2, 4, 5} -> 10
+        val (secondKey, secondRegion) = treeIterator.next() // {3} -> 10
+        val (thirdKey, thirdRegion) = treeIterator.next()   // {3} -> 5
+
+        assertTrue { firstKey == 10 && firstRegion == SetRegion.ofSet(0, 1, 2, 4, 5) }
+        assertTrue { secondKey == 10 && secondRegion == SetRegion.singleton(3) }
+        assertTrue { thirdKey == 5 && thirdRegion == SetRegion.singleton(3) }
+
+        assertFalse { treeIterator.hasNext() }
+        assertThrows<NoSuchElementException> { treeIterator.next() }
+    }
+
+    @Test
+    fun testRecursiveIteratorWritingsInTheSameRegion() {
+        val region = SetRegion.singleton(1)
+        val writes = List(5) { it }
+        val tree = writes.fold(emptyRegionTree<Int, SetRegion<Int>>()) { acc, i ->
+            acc.write(region, i)
+        }
+
+        val iterator = tree.iterator()
+
+        writes.forEach {
+            val (key, currentRegion) = iterator.next()
+            assertTrue { key == it && currentRegion == region }
+        }
+
+        assertFalse { iterator.hasNext() }
+        assertThrows<NoSuchElementException> { iterator.next() }
+    }
+
+
+    @Test
+    fun testRecursiveIteratorComplicatedRegion() {
+        val tree = constructComplicatedTree()
+
+        val nodes = tree.map { it }
+        val expectedValues = listOf(
+            1 to SetRegion.ofSet(7, 8, 9, 10),
+            1 to SetRegion.ofSet(1, 6),
+            1 to SetRegion.ofSet(5),
+            1 to SetRegion.ofSet(4),
+            2 to SetRegion.ofSet(4),
+            3 to SetRegion.ofSet(4, 5),
+            4 to SetRegion.ofSet(4, 5),
+            5 to SetRegion.ofSet(1, 4, 5, 6),
+            1 to SetRegion.singleton(0),
+            6 to SetRegion.singleton(0),
+            1 to SetRegion.singleton(2),
+            2 to SetRegion.singleton(2),
+            5 to SetRegion.singleton(2),
+            7 to SetRegion.singleton(2),
+            1 to SetRegion.singleton(3),
+            2 to SetRegion.singleton(3),
+            3 to SetRegion.singleton(3),
+            5 to SetRegion.singleton(3),
+            8 to SetRegion.singleton(3),
+        )
+
+        nodes.zip(expectedValues).forEach {
+            assertTrue { it.first == it.second }
+        }
+
+        assertThrows<NoSuchElementException> {
+            tree.iterator().let { iterator ->
+                repeat(20) { iterator.next() }
+            }
+        }
+    }
+
+    @Test
+    fun test() {
+        val tree = emptyRegionTree<Int, SetRegion<Int>>()
+            .write(SetRegion.ofSet(1, 2), 10)  // {1, 2} -> 10
+            .write(SetRegion.singleton(1), 1)  // {2} -> 10, {1} -> (1, {1} -> 10)
+            .write(SetRegion.singleton(2), 2)  // {1} -> (1, {1} -> 10), {2} -> (2, {2} -> 10)
+
+        val values = tree.map { it }
+        val expectedValues = listOf(
+            10 to SetRegion.singleton(1),
+            1 to SetRegion.singleton(1),
+            10 to SetRegion.singleton(2),
+            2 to SetRegion.singleton(2)
+        )
+
+        values.zip(expectedValues).forEach {
+            assertTrue { it.first == it.second }
+        }
+    }
+
+    /*
+        {7, 8, 9, 10} -> 1:
+            emptyTree
+        {1, 4, 5, 6} -> 5:
+            {1, 6} -> 1:
+                emptyTree
+            {4, 5} -> 4:
+                {4, 5} -> 3:
+                    {5} -> 1:
+                        emptyTree
+                    {4} -> 2:
+                        {4} -> 1:
+                            emptyTree
+        {0} -> 6:
+            {0} -> 1:
+                emptyTree
+        {2} -> 7:
+            {2} -> 5:
+                {2} -> 2:
+                    {2} -> 1:
+                        emptyTree
+        {3} -> 8:
+            {3} -> 5:
+                {3} -> 3:
+                    {3} -> 2:
+                        {3} -> 1:
+                            emptyTree
+     */
+    private fun constructComplicatedTree(): RegionTree<Int, SetRegion<Int>> {
+        val initialRegion = SetRegion.ofSet(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        val firstRegion = SetRegion.ofSet(2, 3, 4)
+        val secondRegion = SetRegion.ofSet(3, 4, 5)
+        val thirdRegion = SetRegion.ofSet(4, 5)
+        val fourthRegion = SetRegion.ofSet(1, 2, 3, 4, 5, 6)
+
+        val firstPoint = SetRegion.singleton(0)
+        val secondPoint = SetRegion.singleton(2)
+        val thirdPoint = SetRegion.singleton(3)
+
+        return emptyRegionTree<Int, SetRegion<Int>>()
+            .write(initialRegion, 1)
+            .write(firstRegion, 2)
+            .write(secondRegion, 3)
+            .write(thirdRegion, 4)
+            .write(fourthRegion, 5)
+            .write(firstPoint, 6)
+            .write(secondPoint, 7)
+            .write(thirdPoint, 8)
+    }
+}


### PR DESCRIPTION
In this request, I added two iterators: one for `UFlatUpdates` and one for `UTreeUpdates`. Both of them emit elements from the corresponding updates in the FIFO order: the latest updates will be returned in the last order.