### PR TITLE
Fix a wrong regions mapping

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/MemoryRegions.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/MemoryRegions.kt
@@ -163,12 +163,13 @@ data class UMemoryRegion<RegionId : URegionId<Key>, Key, Sort : USort>(
         val mappedUpdates = updates.map(regionId.keyMapper(composer), composer)
         val mappedDefaultValue = defaultValue?.let { composer.compose(it) }
 
-        // If there is no changes after their composition, return unchecked region
-        if (mappedUpdates === updates && mappedDefaultValue === defaultValue) {
+        // Note that we cannot use optimization with unchanged mappedUpdates and mappedDefaultValues here
+        // since in a new region we might have an updated instantiator.
+        // Therefore, we have to check their reference equality as well.
+        if (mappedUpdates === updates && mappedDefaultValue === defaultValue && instantiator === this.instantiator) {
             return this
         }
 
-        // Otherwise, construct a new region with mapped values and a new instantiator.
         return UMemoryRegion(regionId, sort, mappedUpdates, mappedDefaultValue, instantiator)
     }
 


### PR DESCRIPTION
An optimization in `org.usvm.UMemoryRegion#map` led to absent information stored in a new instantiator. Because of this, if later we tried to use it while reading from the region, we'd lose information about updates we have to apply because of this reading. 

This request removes this optimization and adds a test making several compositions of the same expressions on two different heaps with different information.