### PR TITLE
WIP: symbolic collections

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/Composition.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Composition.kt
@@ -4,6 +4,7 @@ import org.usvm.constraints.UTypeEvaluator
 import org.usvm.memory.UReadOnlySymbolicHeap
 import org.usvm.memory.URegionId
 import org.usvm.memory.URegistersStackEvaluator
+import org.usvm.util.Region
 
 @Suppress("MemberVisibilityCanBePrivate")
 open class UComposer<Field, Type>(
@@ -56,6 +57,17 @@ open class UComposer<Field, Type>(
         transformHeapReading(expr, expr.index)
 
     override fun <Sort : USort> transform(expr: UInputFieldReading<Field, Sort>): UExpr<Sort> =
+        transformHeapReading(expr, expr.address)
+
+    override fun <KeySort : USort, Reg : Region<Reg>, Sort : USort> transform(
+        expr: UAllocatedSymbolicMapReading<KeySort, Reg, Sort>
+    ): UExpr<Sort> = transformHeapReading(expr, expr.key)
+
+    override fun <KeySort : USort, Reg : Region<Reg>, Sort : USort> transform(
+        expr: UInputSymbolicMapReading<KeySort, Reg, Sort>
+    ): UExpr<Sort> = transformHeapReading(expr, expr.address to expr.key)
+
+    override fun transform(expr: UInputSymbolicMapLengthReading): USizeExpr =
         transformHeapReading(expr, expr.address)
 
     override fun transform(expr: UConcreteHeapRef): UExpr<UAddressSort> = expr

--- a/usvm-core/src/main/kotlin/org/usvm/Context.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Context.kt
@@ -12,11 +12,15 @@ import io.ksmt.utils.DefaultValueSampler
 import io.ksmt.utils.asExpr
 import io.ksmt.utils.cast
 import org.usvm.memory.UAllocatedArrayRegion
+import org.usvm.memory.UAllocatedSymbolicMapRegion
 import org.usvm.memory.UInputArrayLengthRegion
 import org.usvm.memory.UInputArrayRegion
 import org.usvm.memory.UInputFieldRegion
+import org.usvm.memory.UInputSymbolicMapLengthRegion
+import org.usvm.memory.UInputSymbolicMapRegion
 import org.usvm.memory.splitUHeapRef
 import org.usvm.solver.USolverBase
+import org.usvm.util.Region
 
 @Suppress("LeakingThis")
 open class UContext(
@@ -163,6 +167,37 @@ open class UContext(
     ): UInputArrayLengthReading<ArrayType> = inputArrayLengthReadingCache.createIfContextActive {
         UInputArrayLengthReading(this, region, address)
     }.cast()
+
+    private val allocatedSymbolicMapReadingCache = mkAstInterner<UAllocatedSymbolicMapReading<*, *, *>>()
+
+    fun <KeySort : USort, Reg : Region<Reg>, Sort : USort> mkAllocatedSymbolicMapReading(
+        region: UAllocatedSymbolicMapRegion<KeySort, Reg, Sort>,
+        key: UExpr<KeySort>
+    ): UAllocatedSymbolicMapReading<KeySort, Reg, Sort> =
+        allocatedSymbolicMapReadingCache.createIfContextActive {
+            UAllocatedSymbolicMapReading(this, region, key)
+        }.cast()
+
+    private val inputSymbolicMapReadingCache = mkAstInterner<UInputSymbolicMapReading<*, *, *>>()
+
+    fun <KeySort : USort, Reg : Region<Reg>, Sort : USort> mkInputSymbolicMapReading(
+        region: UInputSymbolicMapRegion<KeySort, Reg, Sort>,
+        address: UHeapRef,
+        key: UExpr<KeySort>
+    ): UInputSymbolicMapReading<KeySort, Reg, Sort> =
+        inputSymbolicMapReadingCache.createIfContextActive {
+            UInputSymbolicMapReading(this, region, address, key)
+        }.cast()
+
+    private val inputSymbolicMapLengthReadingCache = mkAstInterner<UInputSymbolicMapLengthReading>()
+
+    fun mkInputSymbolicMapLengthReading(
+        region: UInputSymbolicMapLengthRegion,
+        address: UHeapRef
+    ): UInputSymbolicMapLengthReading =
+        inputSymbolicMapLengthReadingCache.createIfContextActive {
+            UInputSymbolicMapLengthReading(this, region, address)
+        }
 
     private val indexedMethodReturnValueCache = mkAstInterner<UIndexedMethodReturnValue<Any, out USort>>()
 

--- a/usvm-core/src/main/kotlin/org/usvm/ExprTransformer.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/ExprTransformer.kt
@@ -1,6 +1,7 @@
 package org.usvm
 
 import io.ksmt.expr.transformer.KNonRecursiveTransformer
+import org.usvm.util.Region
 
 abstract class UExprTransformer<Field, Type>(ctx: UContext): KNonRecursiveTransformer(ctx) {
     abstract fun <Sort : USort> transform(expr: USymbol<Sort>): UExpr<Sort>
@@ -12,6 +13,16 @@ abstract class UExprTransformer<Field, Type>(ctx: UContext): KNonRecursiveTransf
     abstract fun <Sort : USort> transform(expr: UAllocatedArrayReading<Type, Sort>): UExpr<Sort>
     abstract fun <Sort : USort> transform(expr: UInputArrayReading<Type, Sort>): UExpr<Sort>
     abstract fun transform(expr: UInputArrayLengthReading<Type>): USizeExpr
+
+    abstract fun <KeySort : USort, Reg : Region<Reg>, Sort : USort> transform(
+        expr: UAllocatedSymbolicMapReading<KeySort, Reg, Sort>
+    ): UExpr<Sort>
+
+    abstract fun <KeySort : USort, Reg : Region<Reg>, Sort : USort> transform(
+        expr: UInputSymbolicMapReading<KeySort, Reg, Sort>
+    ): UExpr<Sort>
+
+    abstract fun transform(expr: UInputSymbolicMapLengthReading): USizeExpr
 
     abstract fun <Sort : USort> transform(expr: UMockSymbol<Sort>): UExpr<Sort>
     abstract fun <Method, Sort : USort> transform(expr: UIndexedMethodReturnValue<Method, Sort>): UExpr<Sort>

--- a/usvm-core/src/main/kotlin/org/usvm/Expressions.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Expressions.kt
@@ -26,15 +26,23 @@ import io.ksmt.sort.KSort
 import io.ksmt.sort.KUninterpretedSort
 import org.usvm.memory.UAllocatedArrayId
 import org.usvm.memory.UAllocatedArrayRegion
+import org.usvm.memory.UAllocatedSymbolicMapId
+import org.usvm.memory.UAllocatedSymbolicMapRegion
 import org.usvm.memory.UInputArrayId
 import org.usvm.memory.UInputArrayLengthId
 import org.usvm.memory.UInputArrayLengthRegion
 import org.usvm.memory.UInputArrayRegion
 import org.usvm.memory.UInputFieldId
 import org.usvm.memory.UInputFieldRegion
+import org.usvm.memory.UInputSymbolicMapId
+import org.usvm.memory.UInputSymbolicMapLengthId
+import org.usvm.memory.UInputSymbolicMapLengthRegion
+import org.usvm.memory.UInputSymbolicMapRegion
 import org.usvm.memory.URegionId
 import org.usvm.memory.USymbolicArrayIndex
+import org.usvm.memory.USymbolicMapKey
 import org.usvm.memory.USymbolicMemoryRegion
+import org.usvm.util.Region
 
 //region KSMT aliases
 
@@ -365,6 +373,99 @@ class UIsExpr<Type> internal constructor(
 
     override fun internHashCode(): Int = hash(ref, type)
 }
+//endregion
+
+// region symbolic collection expressions
+
+class UAllocatedSymbolicMapReading<KeySort : USort, Reg : Region<Reg>, Sort : USort> internal constructor(
+    ctx: UContext,
+    region: UAllocatedSymbolicMapRegion<KeySort, Reg, Sort>,
+    val key: UExpr<KeySort>,
+) : UHeapReading<UAllocatedSymbolicMapId<KeySort, Reg, Sort>, UExpr<KeySort>, Sort>(ctx, region) {
+
+    override fun accept(transformer: KTransformerBase): KExpr<Sort> {
+        require(transformer is UExprTransformer<*, *>)
+        return transformer.transform(this)
+    }
+
+    override fun internEquals(other: Any): Boolean =
+        structurallyEqual(
+            other,
+            { region },
+            { key },
+        )
+
+    override fun internHashCode(): Int = hash(region, key)
+
+    override fun print(printer: ExpressionPrinter) {
+        printer.append(region.toString())
+        printer.append("[")
+        printer.append(key)
+        printer.append("]")
+    }
+}
+
+class UInputSymbolicMapReading<KeySort : USort, Reg : Region<Reg>, Sort : USort> internal constructor(
+    ctx: UContext,
+    region: UInputSymbolicMapRegion<KeySort, Reg, Sort>,
+    val address: UHeapRef,
+    val key: UExpr<KeySort>
+) : UHeapReading<UInputSymbolicMapId<KeySort, Reg, Sort>, USymbolicMapKey<KeySort>, Sort>(ctx, region) {
+    init {
+        require(address !is UNullRef)
+    }
+
+    override fun accept(transformer: KTransformerBase): KExpr<Sort> {
+        require(transformer is UExprTransformer<*, *>)
+        return transformer.transform(this)
+    }
+
+    override fun internEquals(other: Any): Boolean =
+        structurallyEqual(
+            other,
+            { region },
+            { address },
+            { key },
+        )
+
+    override fun internHashCode(): Int = hash(region, address, key)
+
+    override fun print(printer: ExpressionPrinter) {
+        printer.append(region.toString())
+        printer.append("[")
+        printer.append(address)
+        printer.append(", ")
+        printer.append(key)
+        printer.append("]")
+    }
+}
+
+class UInputSymbolicMapLengthReading internal constructor(
+    ctx: UContext,
+    region: UInputSymbolicMapLengthRegion,
+    val address: UHeapRef,
+) : UHeapReading<UInputSymbolicMapLengthId, UHeapRef, USizeSort>(ctx, region) {
+    init {
+        require(address !is UNullRef)
+    }
+
+    override fun accept(transformer: KTransformerBase): USizeExpr {
+        require(transformer is UExprTransformer<*, *>)
+        return transformer.transform(this)
+    }
+
+    override fun internEquals(other: Any): Boolean = structurallyEqual(other, { region }, { address })
+
+    override fun internHashCode(): Int = hash(region, address)
+
+    override fun print(printer: ExpressionPrinter) {
+        printer.append(region.toString())
+        printer.append("[")
+        printer.append(address)
+        printer.append("]")
+    }
+}
+
 //endregion
 
 //region Utils

--- a/usvm-core/src/main/kotlin/org/usvm/constraints/TypeRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/constraints/TypeRegion.kt
@@ -184,4 +184,8 @@ open class UTypeRegion<Type>(
         return RegionComparisonResult.INTERSECTS
     }
 
+    override fun union(other: UTypeRegion<Type>): UTypeRegion<Type> {
+        TODO("Union is not supported for type region")
+    }
+
 }

--- a/usvm-core/src/main/kotlin/org/usvm/intrinsics/EngineIntrinsics.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/intrinsics/EngineIntrinsics.kt
@@ -1,0 +1,28 @@
+package org.usvm.intrinsics
+
+import org.usvm.*
+
+object EngineIntrinsics {
+    fun UState<*, *, *, *>.assume(expr: UBoolExpr) {
+        pathConstraints += expr
+    }
+
+    fun <T : USort> UState<*, *, *, *>.makeSymbolicPrimitive(sort: T): UExpr<T> {
+        check(sort != ctx.addressSort) { "$sort is not primitive" }
+        return ctx.mkFreshConst("symbolic", sort)
+    }
+
+    fun <Type> UState<Type, *, *, *>.makeSymbolicRef(type: Type): UHeapRef {
+        // todo: make input symbolic refs
+        return memory.alloc(type)
+    }
+
+    fun <Type> UState<Type, *, *, *>.makeSymbolicArray(arrayType: Type, size: USizeExpr): UHeapRef {
+        // todo: make input symbolic array
+        return memory.malloc(arrayType, size)
+    }
+
+    fun UState<*, *, *, *>.objectTypeEquals(lhs: UHeapRef, rhs: UHeapRef): UBoolExpr {
+        TODO("Objects types equality check: $lhs, $rhs")
+    }
+}

--- a/usvm-core/src/main/kotlin/org/usvm/intrinsics/collections/SymbolicCollectionIntrinsics.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/intrinsics/collections/SymbolicCollectionIntrinsics.kt
@@ -1,0 +1,62 @@
+package org.usvm.intrinsics.collections
+
+import org.usvm.*
+import org.usvm.memory.USymbolicMapDescriptor
+
+interface SymbolicCollectionIntrinsics {
+
+    fun UState<*, *, *, *>.mkSymbolicCollection(elementSort: USort): UHeapRef = with(memory.heap) {
+        allocate().also { ref ->
+            updateCollectionSize(ref, elementSort, ctx.trueExpr) { ctx.mkBv(0) }
+        }
+    }
+
+    fun UState<*, *, *, *>.symbolicCollectionSize(
+        collection: UHeapRef,
+        elementSort: USort
+    ): USizeExpr = readCollectionSize(collection, elementSort)
+
+    fun UState<*, *, *, *>.symbolicCollectionSizeDescriptor(
+        collection: UHeapRef,
+        elementSort: USort
+    ): USymbolicMapDescriptor<*, *, *>
+
+    fun UState<*, *, *, *>.readCollectionSize(
+        collection: UHeapRef,
+        elementSort: USort
+    ): USizeExpr = readCollectionSize(collection, symbolicCollectionSizeDescriptor(collection, elementSort))
+
+    fun UState<*, *, *, *>.readCollectionSize(
+        collection: UHeapRef,
+        descriptor: USymbolicMapDescriptor<*, *, *>
+    ): USizeExpr {
+        val size = memory.heap.readSymbolicMapLength(descriptor, collection)
+
+        return if (collection is UConcreteHeapRef) {
+            size
+        } else {
+            ctx.ensureAtLeasZero(size)
+        }
+    }
+
+    fun UState<*, *, *, *>.updateCollectionSize(
+        collection: UHeapRef,
+        elementSort: USort,
+        guard: UBoolExpr,
+        update: (USizeExpr) -> USizeExpr
+    ) = updateCollectionSize(collection, symbolicCollectionSizeDescriptor(collection, elementSort), guard, update)
+
+    fun UState<*, *, *, *>.updateCollectionSize(
+        collection: UHeapRef,
+        descriptor: USymbolicMapDescriptor<*, *, *>,
+        guard: UBoolExpr,
+        update: (USizeExpr) -> USizeExpr
+    ) {
+        val oldSize = readCollectionSize(collection, descriptor)
+        val updatedSize = update(oldSize)
+        memory.heap.writeSymbolicMapLength(descriptor, collection, updatedSize, guard)
+    }
+
+    private fun UContext.ensureAtLeasZero(expr: USizeExpr): USizeExpr =
+        mkIte(mkBvSignedGreaterOrEqualExpr(expr, mkSizeExpr(0)), expr, mkSizeExpr(0))
+}

--- a/usvm-core/src/main/kotlin/org/usvm/intrinsics/collections/SymbolicListIntrinsics.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/intrinsics/collections/SymbolicListIntrinsics.kt
@@ -1,0 +1,143 @@
+package org.usvm.intrinsics.collections
+
+import org.usvm.*
+import org.usvm.memory.USymbolicIndexMapDescriptor
+import org.usvm.memory.USymbolicMapDescriptor
+
+object SymbolicListIntrinsics : SymbolicCollectionIntrinsics {
+    object SymbolicListMarker : USymbolicMapDescriptor.SymbolicMapInfo {
+        override fun toString(): String = "List"
+    }
+
+    fun UState<*, *, *, *>.mkSymbolicList(
+        elementSort: USort
+    ): UHeapRef = mkSymbolicCollection(elementSort)
+
+    fun UState<*, *, *, *>.symbolicListSize(
+        listRef: UHeapRef,
+        elementSort: USort
+    ): USizeExpr = symbolicCollectionSize(listRef, elementSort)
+
+    fun UState<*, *, *, *>.symbolicListGet(
+        listRef: UHeapRef,
+        index: USizeExpr,
+        elementSort: USort
+    ): UExpr<out USort> = with(memory.heap) {
+        val descriptor = ctx.listDescriptor(elementSort)
+        readSymbolicMap(descriptor, listRef, index)
+    }
+
+    fun UState<*, *, *, *>.symbolicListAdd(
+        listRef: UHeapRef,
+        elementSort: USort,
+        value: UExpr<out USort>
+    ) = with(memory.heap) {
+        val descriptor = ctx.listDescriptor(elementSort)
+
+        val size = readCollectionSize(listRef, elementSort)
+        writeSymbolicMap(descriptor, listRef, size, value, guard = ctx.trueExpr)
+
+        updateCollectionSize(listRef, elementSort, ctx.trueExpr) { oldSize ->
+            ctx.mkBvAddExpr(oldSize, ctx.mkBv(1))
+        }
+    }
+
+    fun UState<*, *, *, *>.symbolicListSet(
+        listRef: UHeapRef,
+        elementSort: USort,
+        index: USizeExpr,
+        value: UExpr<out USort>
+    ) = with(memory.heap) {
+        val descriptor = ctx.listDescriptor(elementSort)
+        writeSymbolicMap(descriptor, listRef, index, value, guard = ctx.trueExpr)
+    }
+
+    fun UState<*, *, *, *>.symbolicListInsert(
+        listRef: UHeapRef,
+        elementSort: USort,
+        index: USizeExpr,
+        value: UExpr<out USort>
+    ) = with(memory.heap) {
+        val descriptor = ctx.listDescriptor(elementSort)
+
+        val currentSize = readCollectionSize(listRef, elementSort)
+        val srcIndex = ctx.mkBvAddExpr(index, ctx.mkBv(2))
+        val indexAfterInsert = ctx.mkBvAddExpr(index, ctx.mkBv(1))
+        val lastIndexAfterInsert = ctx.mkBvSubExpr(currentSize, ctx.mkBv(1))
+
+        copySymbolicMapIndexRange(
+            descriptor = descriptor,
+            srcRef = listRef,
+            dstRef = listRef,
+            fromSrcKey = srcIndex,
+            fromDstKey = indexAfterInsert,
+            toDstKey = lastIndexAfterInsert,
+            guard = ctx.trueExpr
+        )
+
+        writeSymbolicMap(descriptor, listRef, index, value, guard = ctx.trueExpr)
+        updateCollectionSize(listRef, elementSort, ctx.trueExpr) { oldSize ->
+            ctx.mkBvAddExpr(oldSize, ctx.mkBv(1))
+        }
+    }
+
+    fun UState<*, *, *, *>.symbolicListRemove(
+        listRef: UHeapRef,
+        elementSort: USort,
+        index: USizeExpr
+    ) = with(memory.heap) {
+        val descriptor = ctx.listDescriptor(elementSort)
+
+        val currentSize = readCollectionSize(listRef, elementSort)
+        val firstIndexAfterRemove = ctx.mkBvSubExpr(index, ctx.mkBv(1))
+        val lastIndexAfterRemove = ctx.mkBvSubExpr(currentSize, ctx.mkBv(2))
+
+        copySymbolicMapIndexRange(
+            descriptor = descriptor,
+            srcRef = listRef,
+            dstRef = listRef,
+            fromSrcKey = firstIndexAfterRemove,
+            fromDstKey = index,
+            toDstKey = lastIndexAfterRemove,
+            guard = ctx.trueExpr
+        )
+
+        updateCollectionSize(listRef, elementSort, ctx.trueExpr) { oldSize ->
+            ctx.mkBvSubExpr(oldSize, ctx.mkBv(1))
+        }
+    }
+
+    fun UState<*, *, *, *>.symbolicListCopyRange(
+        srcRef: UHeapRef,
+        dstRef: UHeapRef,
+        elementSort: USort,
+        srcFrom: USizeExpr,
+        dstFrom: USizeExpr,
+        length: USizeExpr
+    ) = with(memory.heap) {
+        val descriptor = ctx.listDescriptor(elementSort)
+
+        val dstTo = ctx.mkBvAddExpr(dstFrom, length)
+
+        copySymbolicMapIndexRange(
+            descriptor = descriptor,
+            srcRef = srcRef,
+            dstRef = dstRef,
+            fromSrcKey = srcFrom,
+            fromDstKey = dstFrom,
+            toDstKey = dstTo,
+            guard = ctx.trueExpr
+        )
+    }
+
+    override fun UState<*, *, *, *>.symbolicCollectionSizeDescriptor(
+        collection: UHeapRef,
+        elementSort: USort
+    ): USymbolicMapDescriptor<*, *, *> = ctx.listDescriptor(elementSort)
+
+    private fun UContext.listDescriptor(valueSort: USort) = USymbolicIndexMapDescriptor(
+        valueSort = valueSort,
+        defaultValue = valueSort.sampleUValue(),
+        info = SymbolicListMarker
+    )
+}

--- a/usvm-core/src/main/kotlin/org/usvm/intrinsics/collections/SymbolicObjectMapIntrinsics.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/intrinsics/collections/SymbolicObjectMapIntrinsics.kt
@@ -1,0 +1,138 @@
+package org.usvm.intrinsics.collections
+
+import io.ksmt.utils.asExpr
+import io.ksmt.utils.mkFreshConst
+import org.usvm.*
+import org.usvm.memory.USymbolicMapDescriptor
+import org.usvm.memory.USymbolicObjectReferenceMapDescriptor
+
+object SymbolicObjectMapIntrinsics : SymbolicCollectionIntrinsics {
+    data class SymbolicObjectMapValueMarker(
+        val valueSort: USort
+    ) : USymbolicMapDescriptor.SymbolicMapInfo {
+        override fun toString(): String = "Map<$valueSort>Value"
+    }
+
+    data class SymbolicObjectMapContainsMarker(
+        val valueSort: USort
+    ) : USymbolicMapDescriptor.SymbolicMapInfo {
+        override fun toString(): String = "Map<$valueSort>Contains"
+    }
+
+    fun UState<*, *, *, *>.mkSymbolicObjectMap(elementSort: USort): UHeapRef =
+        mkSymbolicCollection(elementSort)
+
+    // todo: input map size can be inconsistent with contains
+    fun UState<*, *, *, *>.symbolicObjectMapSize(mapRef: UHeapRef, elementSort: USort): USizeExpr =
+        symbolicCollectionSize(mapRef, elementSort)
+
+    fun UState<*, *, *, *>.symbolicObjectMapGet(
+        mapRef: UHeapRef,
+        key: UHeapRef,
+        elementSort: USort
+    ): UExpr<out USort> = with(memory.heap) {
+        val descriptor = ctx.valueDescriptor(elementSort)
+        val keyId = mkKeyId(key)
+        readSymbolicMap(descriptor, mapRef, keyId)
+    }
+
+    fun UState<*, *, *, *>.symbolicObjectMapContains(
+        mapRef: UHeapRef,
+        key: UHeapRef,
+        elementSort: USort
+    ): UBoolExpr = with(memory.heap) {
+        val descriptor = ctx.containsDescriptor(elementSort)
+        val keyId = mkKeyId(key)
+        readSymbolicMap(descriptor, mapRef, keyId).asExpr(ctx.boolSort)
+    }
+
+    fun UState<*, *, *, *>.symbolicObjectMapPut(
+        mapRef: UHeapRef,
+        key: UHeapRef,
+        elementSort: USort,
+        value: UExpr<out USort>
+    ): Unit = with(memory.heap) {
+        val valueDescriptor = ctx.valueDescriptor(elementSort)
+        val containsDescriptor = ctx.containsDescriptor(elementSort)
+
+        val keyId = mkKeyId(key)
+
+        val keyIsInMap = readSymbolicMap(containsDescriptor, mapRef, keyId).asExpr(ctx.boolSort)
+        val keyIsNew = ctx.mkNot(keyIsInMap)
+
+        writeSymbolicMap(valueDescriptor, mapRef, keyId, value, guard = ctx.trueExpr)
+        writeSymbolicMap(containsDescriptor, mapRef, keyId, value = ctx.trueExpr, guard = ctx.trueExpr)
+        updateCollectionSize(mapRef, elementSort, keyIsNew) { ctx.mkBvAddExpr(it, ctx.mkBv(1)) }
+    }
+
+    fun UState<*, *, *, *>.symbolicObjectMapRemove(
+        mapRef: UHeapRef,
+        key: UHeapRef,
+        elementSort: USort
+    ): Unit = with(memory.heap) {
+        val containsDescriptor = ctx.containsDescriptor(elementSort)
+
+        val keyId = mkKeyId(key)
+
+        val keyIsInMap = readSymbolicMap(containsDescriptor, mapRef, keyId).asExpr(ctx.boolSort)
+
+        // todo: skip values update?
+        writeSymbolicMap(containsDescriptor, mapRef, keyId, value = ctx.falseExpr, guard = ctx.trueExpr)
+        updateCollectionSize(mapRef, elementSort, keyIsInMap) { ctx.mkBvSubExpr(it, ctx.mkBv(1)) }
+    }
+
+    fun UState<*, *, *, *>.symbolicObjectMapMergeInto(
+        dstRef: UHeapRef,
+        srcRef: UHeapRef,
+        elementSort: USort
+    ): Unit = with(memory.heap) {
+        val valueDescriptor = ctx.valueDescriptor(elementSort)
+        val containsDescriptor = ctx.containsDescriptor(elementSort)
+
+        mergeSymbolicMap(
+            descriptor = valueDescriptor,
+            keyContainsDescriptor = containsDescriptor,
+            srcRef = srcRef,
+            dstRef = dstRef,
+            guard = ctx.trueExpr
+        )
+
+        mergeSymbolicMap(
+            descriptor = containsDescriptor,
+            keyContainsDescriptor = containsDescriptor,
+            srcRef = srcRef,
+            dstRef = dstRef,
+            guard = ctx.trueExpr
+        )
+
+        // todo: precise map size approximation?
+        val mergedMapSize = ctx.sizeSort.mkFreshConst("mergedMapSize")
+        val srcMapSize = symbolicCollectionSize(srcRef, elementSort)
+        val dstMapSize = symbolicCollectionSize(dstRef, elementSort)
+        val sizeLowerBound = ctx.mkIte(ctx.mkBvSignedGreaterExpr(srcMapSize, dstMapSize), srcMapSize, dstMapSize)
+        val sizeUpperBound = ctx.mkBvAddExpr(srcMapSize, dstMapSize)
+        pathConstraints += ctx.mkBvSignedGreaterOrEqualExpr(mergedMapSize, sizeLowerBound)
+        pathConstraints += ctx.mkBvSignedGreaterOrEqualExpr(mergedMapSize, sizeUpperBound)
+        updateCollectionSize(dstRef, elementSort, ctx.trueExpr) { mergedMapSize }
+    }
+
+    override fun UState<*, *, *, *>.symbolicCollectionSizeDescriptor(
+        collection: UHeapRef,
+        elementSort: USort
+    ): USymbolicMapDescriptor<*, *, *> = ctx.containsDescriptor(elementSort)
+
+    // todo: use identity equality instead of reference equality
+    private fun mkKeyId(key: UHeapRef): UHeapRef = key
+
+    private fun UContext.valueDescriptor(valueSort: USort) = USymbolicObjectReferenceMapDescriptor(
+        valueSort = valueSort,
+        defaultValue = valueSort.sampleUValue(),
+        info = SymbolicObjectMapValueMarker(valueSort)
+    )
+
+    private fun UContext.containsDescriptor(valueSort: USort) = USymbolicObjectReferenceMapDescriptor(
+        valueSort = boolSort,
+        defaultValue = falseExpr,
+        info = SymbolicObjectMapContainsMarker(valueSort)
+    )
+}

--- a/usvm-core/src/main/kotlin/org/usvm/memory/SymbolicMapDescriptor.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/memory/SymbolicMapDescriptor.kt
@@ -1,0 +1,116 @@
+package org.usvm.memory
+
+import io.ksmt.cache.hash
+import org.usvm.UAddressSort
+import org.usvm.UBoolExpr
+import org.usvm.UConcreteHeapRef
+import org.usvm.UExpr
+import org.usvm.UHeapRef
+import org.usvm.USizeSort
+import org.usvm.USort
+import org.usvm.uctx
+import org.usvm.util.Region
+import org.usvm.util.SetRegion
+
+abstract class USymbolicMapDescriptor<Key : USort, Value : USort, Reg : Region<Reg>> {
+    abstract val keySort: Key
+    abstract val valueSort: Value
+    abstract val defaultValue: UExpr<Value> // not used for descriptor comparison
+    abstract val info: SymbolicMapInfo?
+
+    abstract fun mkKeyRegion(key: UExpr<Key>): Reg
+    abstract fun mkKeyRangeRegion(key1: UExpr<Key>, key2: UExpr<Key>): Reg
+    abstract fun mkKeyUniverseRegion(): Reg
+    abstract fun mkKeyEmptyRegion(): Reg
+
+    abstract fun keyEqSymbolic(key1: UExpr<Key>, key2: UExpr<Key>): UBoolExpr
+    abstract fun keyCmpSymbolic(key1: UExpr<Key>, key2: UExpr<Key>): UBoolExpr
+    abstract fun keyCmpConcrete(key1: UExpr<Key>, key2: UExpr<Key>): Boolean
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as USymbolicMapDescriptor<*, *, *>
+
+        if (keySort != other.keySort) return false
+        if (valueSort != other.valueSort) return false
+        return info == other.info
+    }
+
+    override fun hashCode(): Int = hash(keySort, valueSort, info)
+    override fun toString(): String =
+        "Descriptor(keySort=$keySort, valueSort=$valueSort, info=$info)"
+
+    interface SymbolicMapInfo
+}
+
+class USymbolicObjectReferenceMapDescriptor<Value : USort>(
+    override val valueSort: Value,
+    override val defaultValue: UExpr<Value>,
+    override val info: SymbolicMapInfo? = null
+) : USymbolicMapDescriptor<UAddressSort, Value, SetRegion<UHeapRef>>() {
+
+    override val keySort: UAddressSort = valueSort.uctx.addressSort
+
+    override fun mkKeyRegion(
+        key: UHeapRef
+    ): SetRegion<UHeapRef> = if (key is UConcreteHeapRef){
+        SetRegion.singleton(key)
+    } else {
+        SetRegion.universe()
+    }
+
+    override fun mkKeyRangeRegion(
+        key1: UHeapRef,
+        key2: UHeapRef
+    ) = error("Heap references should not be used in range queries!")
+
+    override fun mkKeyUniverseRegion(): SetRegion<UHeapRef> = SetRegion.universe()
+
+    override fun mkKeyEmptyRegion(): SetRegion<UHeapRef> = SetRegion.empty()
+
+    override fun keyEqSymbolic(
+        key1: UHeapRef,
+        key2: UHeapRef
+    ): UBoolExpr = with(key1.ctx) {
+        key1 eq key2
+    }
+
+    override fun keyCmpSymbolic(
+        key1: UHeapRef,
+        key2: UHeapRef
+    ): UBoolExpr = error("Heap references should not be compared!")
+
+    override fun keyCmpConcrete(
+        key1: UHeapRef,
+        key2: UHeapRef
+    ): Boolean = error("Heap references should not be compared!")
+}
+
+class USymbolicIndexMapDescriptor<Value : USort>(
+    override val valueSort: Value,
+    override val defaultValue: UExpr<Value>,
+    override val info: SymbolicMapInfo? = null
+) : USymbolicMapDescriptor<USizeSort, Value, UArrayIndexRegion>() {
+    override val keySort: USizeSort = valueSort.uctx.sizeSort
+
+    override fun mkKeyRegion(key: UExpr<USizeSort>): UArrayIndexRegion =
+        indexRegion(key)
+
+    override fun mkKeyRangeRegion(key1: UExpr<USizeSort>, key2: UExpr<USizeSort>): UArrayIndexRegion =
+        indexRangeRegion(key1, key2)
+
+    override fun mkKeyUniverseRegion(): UArrayIndexRegion = indexUniverseRangeRegion()
+
+    override fun mkKeyEmptyRegion(): UArrayIndexRegion = indexEmptyRangeRegion()
+
+    override fun keyEqSymbolic(key1: UExpr<USizeSort>, key2: UExpr<USizeSort>): UBoolExpr =
+        indexEq(key1, key2)
+
+    override fun keyCmpSymbolic(key1: UExpr<USizeSort>, key2: UExpr<USizeSort>): UBoolExpr =
+        indexLeSymbolic(key1, key2)
+
+    override fun keyCmpConcrete(key1: UExpr<USizeSort>, key2: UExpr<USizeSort>): Boolean =
+        indexLeConcrete(key1, key2)
+}

--- a/usvm-core/src/main/kotlin/org/usvm/memory/UpdateNodes.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/memory/UpdateNodes.kt
@@ -1,11 +1,17 @@
 package org.usvm.memory
 
+import io.ksmt.utils.uncheckedCast
 import org.usvm.UBoolExpr
+import org.usvm.UBoolSort
 import org.usvm.UComposer
 import org.usvm.UExpr
+import org.usvm.UHeapRef
 import org.usvm.USizeExpr
 import org.usvm.USort
+import org.usvm.isFalse
 import org.usvm.isTrue
+import org.usvm.uctx
+import org.usvm.util.Region
 import java.util.*
 
 /**
@@ -141,126 +147,26 @@ class UPinpointUpdateNode<Key, Sort : USort>(
     override fun toString(): String = "{$key <- $value}".takeIf { guard.isTrue } ?: "{$key <- $value | $guard}"
 }
 
-/**
- * Composable converter of memory region keys. Helps to transparently copy content of various regions
- * each into other without eager address conversion.
- * For instance, when we copy array slice [i : i + len] to destination memory slice [j : j + len],
- * we emulate it by memorizing the source memory updates as-is, but read the destination memory by
- * 'redirecting' the index k to k + j - i of the source memory.
- * This conversion is done by [convert].
- * Do not be confused: it converts [DstKey] to [SrcKey] (not vice-versa), as we use it when we
- * read from destination buffer index to source memory.
- */
-sealed class UMemoryKeyConverter<SrcKey, DstKey>(
-    val srcSymbolicArrayIndex: USymbolicArrayIndex,
-    val dstFromSymbolicArrayIndex: USymbolicArrayIndex,
-    val dstToIndex: USizeExpr
-) {
+sealed interface UMemoryKeyConverterBase<SrcKey, DstKey, T : UMemoryKeyConverterBase<SrcKey, DstKey, T>> {
     /**
-     * Converts source memory key into destination memory key
+     * Converts destination memory key into source memory key
      */
-    abstract fun convert(key: DstKey): SrcKey
+    fun convert(key: DstKey): SrcKey
 
-    protected fun convertIndex(idx: USizeExpr): USizeExpr = with(srcSymbolicArrayIndex.first.ctx) {
-        mkBvSubExpr(mkBvAddExpr(idx, dstFromSymbolicArrayIndex.second), srcSymbolicArrayIndex.second)
-    }
-
-    abstract fun clone(
-        srcSymbolicArrayIndex: USymbolicArrayIndex,
-        dstFromSymbolicArrayIndex: USymbolicArrayIndex,
-        dstToIndex: USizeExpr
-    ): UMemoryKeyConverter<SrcKey, DstKey>
-
-    fun <Field, Type> map(composer: UComposer<Field, Type>): UMemoryKeyConverter<SrcKey, DstKey> {
-        val (srcRef, srcIdx) = srcSymbolicArrayIndex
-        val (dstRef, dstIdx) = dstFromSymbolicArrayIndex
-
-        val newSrcHeapAddr = composer.compose(srcRef)
-        val newSrcArrayIndex = composer.compose(srcIdx)
-        val newDstHeapAddress = composer.compose(dstRef)
-        val newDstFromIndex = composer.compose(dstIdx)
-        val newDstToIndex = composer.compose(dstToIndex)
-
-        if (newSrcHeapAddr === srcRef &&
-            newSrcArrayIndex === srcIdx &&
-            newDstHeapAddress === dstRef &&
-            newDstFromIndex === dstIdx &&
-            newDstToIndex === dstToIndex
-        ) {
-            return this
-        }
-
-        return clone(
-            srcSymbolicArrayIndex = newSrcHeapAddr to newSrcArrayIndex,
-            dstFromSymbolicArrayIndex = newDstHeapAddress to newDstFromIndex,
-            dstToIndex = newDstToIndex
-        )
-    }
+    fun <Field, Type> map(composer: UComposer<Field, Type>): T
 }
 
-/**
- * Represents a synchronous overwriting the range of addresses [[fromKey] : [toKey]]
- * with values from memory region [region] read from range
- * of addresses [[keyConverter].convert([fromKey]) : [keyConverter].convert([toKey])]
- */
-class URangedUpdateNode<RegionId : UArrayId<*, SrcKey, Sort, RegionId>, SrcKey, DstKey, Sort : USort>(
-    val fromKey: DstKey,
-    val toKey: DstKey,
-    val region: USymbolicMemoryRegion<RegionId, SrcKey, Sort>,
-    private val concreteComparer: (DstKey, DstKey) -> Boolean,
-    private val symbolicComparer: (DstKey, DstKey) -> UBoolExpr,
-    val keyConverter: UMemoryKeyConverter<SrcKey, DstKey>,
-    override val guard: UBoolExpr
-) : UUpdateNode<DstKey, Sort> {
-    override fun includesConcretely(key: DstKey, precondition: UBoolExpr): Boolean =
-        concreteComparer(fromKey, key) && concreteComparer(key, toKey) &&
-            (guard == guard.ctx.trueExpr || precondition == guard) // TODO: some optimizations here?
-    // in fact, we can check less strict formulae: precondition _implies_ guard, but this is too complex to compute.
-
-    override fun includesSymbolically(key: DstKey): UBoolExpr {
-        val leftIsLefter = symbolicComparer(fromKey, key)
-        val rightIsRighter = symbolicComparer(key, toKey)
-        val ctx = leftIsLefter.ctx
-
-        return ctx.mkAnd(leftIsLefter, rightIsRighter, guard)
-    }
-
-    override fun isIncludedByUpdateConcretely(update: UUpdateNode<DstKey, Sort>): Boolean =
-        update.includesConcretely(fromKey, guard) && update.includesConcretely(toKey, guard)
+sealed interface UMemoryRegionUpdate<
+        SrcKey, DstKey, Sort : USort,
+        Region : USymbolicMemoryRegion<*, SrcKey, Sort>,
+        KeyConverter : UMemoryKeyConverterBase<SrcKey, DstKey, KeyConverter>
+        > : UUpdateNode<DstKey, Sort> {
+    val keyConverter: KeyConverter
+    val region: Region
 
     override fun value(key: DstKey): UExpr<Sort> = region.read(keyConverter.convert(key))
 
-    override fun <Field, Type> map(
-        keyMapper: KeyMapper<DstKey>,
-        composer: UComposer<Field, Type>
-    ): URangedUpdateNode<RegionId, SrcKey, DstKey, Sort> {
-        val mappedFromKey = keyMapper(fromKey)
-        val mappedToKey = keyMapper(toKey)
-        val mappedRegion = region.map(composer)
-        val mappedKeyConverter = keyConverter.map(composer)
-        val mappedGuard = composer.compose(guard)
-
-        // If nothing changed, return this
-        if (mappedFromKey === fromKey
-            && mappedToKey === toKey
-            && mappedRegion === region
-            && mappedKeyConverter === keyConverter
-            && mappedGuard === guard
-        ) {
-            return this
-        }
-
-        // Otherwise, construct a new one updated node
-        return URangedUpdateNode(
-            mappedFromKey,
-            mappedToKey,
-            mappedRegion,
-            concreteComparer,
-            symbolicComparer,
-            mappedKeyConverter,
-            mappedGuard
-        )
-    }
+    fun changeRegion(newRegion: Region): UUpdateNode<DstKey, Sort>
 
     override fun split(
         key: DstKey,
@@ -303,13 +209,140 @@ class URangedUpdateNode<RegionId : UArrayId<*, SrcKey, Sort, RegionId>, SrcKey, 
         val resultUpdateNode = if (splitRegion === region) {
             this
         } else {
-            URangedUpdateNode(fromKey, toKey, splitRegion, concreteComparer, symbolicComparer, keyConverter, guard)
+            @Suppress("UNCHECKED_CAST")
+            changeRegion(splitRegion as Region)
         }
 
         guardBuilder += nodeExcludesKey
 
         return resultUpdateNode
     }
+}
+
+/**
+ * Composable converter of memory region keys. Helps to transparently copy content of various regions
+ * each into other without eager address conversion.
+ * For instance, when we copy array slice [i : i + len] to destination memory slice [j : j + len],
+ * we emulate it by memorizing the source memory updates as-is, but read the destination memory by
+ * 'redirecting' the index k to k + j - i of the source memory.
+ * This conversion is done by [convert].
+ * Do not be confused: it converts [DstKey] to [SrcKey] (not vice-versa), as we use it when we
+ * read from destination buffer index to source memory.
+ */
+sealed class UMemoryKeyConverter<SrcKey, DstKey>(
+    val srcSymbolicArrayIndex: USymbolicArrayIndex,
+    val dstFromSymbolicArrayIndex: USymbolicArrayIndex,
+    val dstToIndex: USizeExpr
+): UMemoryKeyConverterBase<SrcKey, DstKey, UMemoryKeyConverter<SrcKey, DstKey>> {
+    /**
+     * Converts source memory key into destination memory key
+     */
+    abstract override fun convert(key: DstKey): SrcKey
+
+    protected fun convertIndex(idx: USizeExpr): USizeExpr = with(srcSymbolicArrayIndex.first.ctx) {
+        mkBvSubExpr(mkBvAddExpr(idx, dstFromSymbolicArrayIndex.second), srcSymbolicArrayIndex.second)
+    }
+
+    abstract fun clone(
+        srcSymbolicArrayIndex: USymbolicArrayIndex,
+        dstFromSymbolicArrayIndex: USymbolicArrayIndex,
+        dstToIndex: USizeExpr
+    ): UMemoryKeyConverter<SrcKey, DstKey>
+
+    override fun <Field, Type> map(composer: UComposer<Field, Type>): UMemoryKeyConverter<SrcKey, DstKey> {
+        val (srcRef, srcIdx) = srcSymbolicArrayIndex
+        val (dstRef, dstIdx) = dstFromSymbolicArrayIndex
+
+        val newSrcHeapAddr = composer.compose(srcRef)
+        val newSrcArrayIndex = composer.compose(srcIdx)
+        val newDstHeapAddress = composer.compose(dstRef)
+        val newDstFromIndex = composer.compose(dstIdx)
+        val newDstToIndex = composer.compose(dstToIndex)
+
+        if (newSrcHeapAddr === srcRef &&
+            newSrcArrayIndex === srcIdx &&
+            newDstHeapAddress === dstRef &&
+            newDstFromIndex === dstIdx &&
+            newDstToIndex === dstToIndex
+        ) {
+            return this
+        }
+
+        return clone(
+            srcSymbolicArrayIndex = newSrcHeapAddr to newSrcArrayIndex,
+            dstFromSymbolicArrayIndex = newDstHeapAddress to newDstFromIndex,
+            dstToIndex = newDstToIndex
+        )
+    }
+}
+
+/**
+ * Represents a synchronous overwriting the range of addresses [[fromKey] : [toKey]]
+ * with values from memory region [region] read from range
+ * of addresses [[keyConverter].convert([fromKey]) : [keyConverter].convert([toKey])]
+ */
+class URangedUpdateNode<RegionId : UArrayId<SrcKey, Sort, RegionId>, SrcKey, DstKey, Sort : USort>(
+    val fromKey: DstKey,
+    val toKey: DstKey,
+    override val region: USymbolicMemoryRegion<RegionId, SrcKey, Sort>,
+    private val concreteComparer: (DstKey, DstKey) -> Boolean,
+    private val symbolicComparer: (DstKey, DstKey) -> UBoolExpr,
+    override val keyConverter: UMemoryKeyConverter<SrcKey, DstKey>,
+    override val guard: UBoolExpr
+) : UMemoryRegionUpdate<SrcKey, DstKey, Sort,
+        USymbolicMemoryRegion<RegionId, SrcKey, Sort>,
+        UMemoryKeyConverter<SrcKey, DstKey>> {
+
+    override fun includesConcretely(key: DstKey, precondition: UBoolExpr): Boolean =
+        concreteComparer(fromKey, key) && concreteComparer(key, toKey) &&
+            (guard == guard.ctx.trueExpr || precondition == guard) // TODO: some optimizations here?
+    // in fact, we can check less strict formulae: precondition _implies_ guard, but this is too complex to compute.
+
+    override fun includesSymbolically(key: DstKey): UBoolExpr {
+        val leftIsLefter = symbolicComparer(fromKey, key)
+        val rightIsRighter = symbolicComparer(key, toKey)
+        val ctx = leftIsLefter.ctx
+
+        return ctx.mkAnd(leftIsLefter, rightIsRighter, guard)
+    }
+
+    override fun isIncludedByUpdateConcretely(update: UUpdateNode<DstKey, Sort>): Boolean =
+        update.includesConcretely(fromKey, guard) && update.includesConcretely(toKey, guard)
+
+    override fun <Field, Type> map(
+        keyMapper: KeyMapper<DstKey>,
+        composer: UComposer<Field, Type>
+    ): URangedUpdateNode<RegionId, SrcKey, DstKey, Sort> {
+        val mappedFromKey = keyMapper(fromKey)
+        val mappedToKey = keyMapper(toKey)
+        val mappedRegion = region.map(composer)
+        val mappedKeyConverter = keyConverter.map(composer)
+        val mappedGuard = composer.compose(guard)
+
+        // If nothing changed, return this
+        if (mappedFromKey === fromKey
+            && mappedToKey === toKey
+            && mappedRegion === region
+            && mappedKeyConverter === keyConverter
+            && mappedGuard === guard
+        ) {
+            return this
+        }
+
+        // Otherwise, construct a new one updated node
+        return URangedUpdateNode(
+            mappedFromKey,
+            mappedToKey,
+            mappedRegion,
+            concreteComparer,
+            symbolicComparer,
+            mappedKeyConverter,
+            mappedGuard
+        )
+    }
+
+    override fun changeRegion(newRegion: USymbolicMemoryRegion<RegionId, SrcKey, Sort>) =
+        URangedUpdateNode(fromKey, toKey, newRegion, concreteComparer, symbolicComparer, keyConverter, guard)
 
     // Ignores update
     override fun equals(other: Any?): Boolean =
@@ -325,6 +358,201 @@ class URangedUpdateNode<RegionId : UArrayId<*, SrcKey, Sort, RegionId>, SrcKey, 
         return "{[$fromKey..$toKey] <- $region[keyConv($fromKey)..keyConv($toKey)]" +
             ("}".takeIf { guard.isTrue } ?: " | $guard}")
     }
+}
+
+class UMergeKeyConverter<SrcKey, DstKey>(
+    val srcRef: UHeapRef,
+    val dstRef: UHeapRef,
+    val converter: UMergeKeyConverter<SrcKey, DstKey>.(DstKey) -> SrcKey
+) : UMemoryKeyConverterBase<SrcKey, DstKey, UMergeKeyConverter<SrcKey, DstKey>> {
+    override fun convert(key: DstKey): SrcKey = converter(key)
+
+    override fun <Field, Type> map(composer: UComposer<Field, Type>): UMergeKeyConverter<SrcKey, DstKey> {
+        val mappedSrc = composer.compose(srcRef)
+        val mappedDst = composer.compose(dstRef)
+        if (mappedSrc === srcRef && mappedDst == dstRef) {
+            return this
+        }
+        return UMergeKeyConverter(mappedSrc, mappedDst, converter)
+    }
+}
+
+abstract class UMergeKeyIncludesCheck<
+        SrcKey,
+        KeySort : USort,
+        RegionId : USymbolicMapId<SrcKey, KeySort, *, UBoolSort, RegionId>,
+        Reg : Region<Reg>>(
+    val region: USymbolicMemoryRegion<RegionId, SrcKey, UBoolSort>,
+    val mkKeyRegion: (SrcKey) -> Reg,
+    val mkEmptyRegion: () -> Reg,
+    val mkUniverseRegion: () -> Reg
+) {
+    fun check(key: SrcKey): UBoolExpr = region.read(key)
+
+    private val keyRegionBuilder = KeyRegionBuilder()
+    private val keyRegionCache = IdentityHashMap<Any?, Reg>()
+
+    abstract fun initialKeyRegion(): Reg
+
+    private inner class KeyRegionBuilder: UMemoryUpdatesVisitor<SrcKey, UBoolSort, Reg>{
+        override fun visitSelect(result: Reg, key: SrcKey): UExpr<UBoolSort> {
+            error("Unexpected reading")
+        }
+
+        override fun visitInitialValue(): Reg = initialKeyRegion()
+
+        override fun visitUpdate(previous: Reg, update: UUpdateNode<SrcKey, UBoolSort>): Reg = when (update) {
+            is UMergeUpdateNode<*, *, *, *, *, UBoolSort> -> {
+                val updatedKeys: Reg = update.keyIncludesCheck.keyRegion().uncheckedCast()
+                previous.union(updatedKeys)
+            }
+
+            is UPinpointUpdateNode -> {
+                // todo: removed keys
+                val keyReg = mkKeyRegion(update.key)
+                previous.union(keyReg)
+            }
+
+            is URangedUpdateNode<*, *, *, *> -> error("Unexpected range update")
+        }
+    }
+
+    fun keyRegion(): Reg =
+        region.updates.accept(keyRegionBuilder, keyRegionCache)
+
+    abstract fun <Field, Type> map(composer: UComposer<Field, Type>): UMergeKeyIncludesCheck<SrcKey, KeySort, RegionId, Reg>
+}
+
+class UMergeKeyIncludesCheckAllocated<
+        SrcKey,
+        KeySort : USort,
+        RegionId : USymbolicMapId<SrcKey, KeySort, *, UBoolSort, RegionId>,
+        Reg : Region<Reg>>(
+    region: USymbolicMemoryRegion<RegionId, SrcKey, UBoolSort>,
+    mkKeyRegion: (SrcKey) -> Reg,
+    mkEmptyRegion: () -> Reg,
+    mkUniverseRegion: () -> Reg
+) : UMergeKeyIncludesCheck<SrcKey, KeySort, RegionId, Reg>(region, mkKeyRegion, mkEmptyRegion, mkUniverseRegion) {
+
+    override fun initialKeyRegion(): Reg = mkEmptyRegion()
+
+    override fun <Field, Type> map(composer: UComposer<Field, Type>): UMergeKeyIncludesCheck<SrcKey, KeySort, RegionId, Reg> {
+        val mappedRegion = region.map(composer)
+        if (mappedRegion === region) return this
+        return UMergeKeyIncludesCheckAllocated(mappedRegion, mkKeyRegion, mkEmptyRegion, mkUniverseRegion)
+    }
+}
+
+class UMergeKeyIncludesCheckInput<
+        KeySort : USort,
+        RegionId : USymbolicMapId<USymbolicMapKey<KeySort>, KeySort, *, UBoolSort, RegionId>,
+        Reg : Region<Reg>>(
+    val ref: UHeapRef,
+    region: USymbolicMemoryRegion<RegionId, USymbolicMapKey<KeySort>, UBoolSort>,
+    mkKeyRegion: (USymbolicMapKey<KeySort>) -> Reg,
+    mkEmptyRegion: () -> Reg,
+    mkUniverseRegion: () -> Reg
+) : UMergeKeyIncludesCheck<USymbolicMapKey<KeySort>, KeySort, RegionId, Reg>(
+    region, mkKeyRegion, mkEmptyRegion, mkUniverseRegion
+) {
+
+    override fun initialKeyRegion(): Reg {
+        // allocated region
+        if (region.defaultValue != null) {
+            return mkEmptyRegion()
+        }
+
+        val regionId: USymbolicMapId<USymbolicMapKey<KeySort>, KeySort, *, UBoolSort, RegionId> = region.regionId
+
+        // unexpected region
+        if (regionId !is UInputSymbolicMapId<KeySort, *, UBoolSort>) {
+            return mkUniverseRegion()
+        }
+
+        return regionId.visitInputMapUpdates(object : UInputSymbolicMapUpdatesVisitor<KeySort, UBoolSort, Reg> {
+            override fun visitInputValue(): Reg = mkUniverseRegion()
+
+            override fun visitUpdate(previous: Reg, key: USymbolicMapKey<KeySort>, value: UExpr<UBoolSort>): Reg {
+                val refEquals = ref.uctx.mkHeapRefEq(ref, key.first)
+                if (refEquals.isFalse) return mkEmptyRegion()
+                if (!refEquals.isTrue) return mkUniverseRegion()
+
+                val keyReg = mkKeyRegion(key)
+                // todo: removed keys
+                return previous.union(keyReg)
+            }
+
+            override fun visitBaseValue(value: UExpr<UBoolSort>): Reg = if (value.isFalse) {
+                mkEmptyRegion()
+            } else {
+                mkUniverseRegion()
+            }
+        })
+    }
+
+    override fun <Field, Type> map(
+        composer: UComposer<Field, Type>
+    ): UMergeKeyIncludesCheck<USymbolicMapKey<KeySort>, KeySort, RegionId, Reg> {
+        val mappedRef = composer.compose(ref)
+        val mappedRegion = region.map(composer)
+        if (mappedRef === ref && mappedRegion === region) return this
+        return UMergeKeyIncludesCheckInput(mappedRef, mappedRegion, mkKeyRegion, mkEmptyRegion, mkUniverseRegion)
+    }
+}
+
+class UMergeUpdateNode<
+        RegionId : USymbolicMapId<SrcKey, KeySort, Reg, ValueSort, RegionId>,
+        SrcKey,
+        DstKey,
+        KeySort : USort,
+        Reg : Region<Reg>,
+        ValueSort : USort>(
+    override val region: USymbolicMemoryRegion<RegionId, SrcKey, ValueSort>,
+    val keyIncludesCheck: UMergeKeyIncludesCheck<SrcKey, KeySort, *, Reg>,
+    override val keyConverter: UMergeKeyConverter<SrcKey, DstKey>,
+    override val guard: UBoolExpr
+) : UMemoryRegionUpdate<SrcKey, DstKey, ValueSort,
+        USymbolicMemoryRegion<RegionId, SrcKey, ValueSort>,
+        UMergeKeyConverter<SrcKey, DstKey>> {
+
+    override fun includesConcretely(key: DstKey, precondition: UBoolExpr): Boolean {
+        val srcKey = keyConverter.convert(key)
+        val keyIncludes = keyIncludesCheck.check(srcKey)
+        return (keyIncludes === keyIncludes.ctx.trueExpr) && (guard == guard.ctx.trueExpr || precondition == guard)
+    }
+
+    override fun isIncludedByUpdateConcretely(update: UUpdateNode<DstKey, ValueSort>): Boolean = false
+
+    override fun includesSymbolically(key: DstKey): UBoolExpr {
+        val srcKey = keyConverter.convert(key)
+        val keyIncludes = keyIncludesCheck.check(srcKey)
+        return keyIncludes.ctx.mkAnd(keyIncludes, guard)
+    }
+
+    override fun changeRegion(newRegion: USymbolicMemoryRegion<RegionId, SrcKey, ValueSort>) =
+        UMergeUpdateNode(newRegion, keyIncludesCheck, keyConverter, guard)
+
+    override fun <Field, Type> map(
+        keyMapper: KeyMapper<DstKey>,
+        composer: UComposer<Field, Type>
+    ): UUpdateNode<DstKey, ValueSort> {
+        val mappedRegion = region.map(composer)
+        val mappedKeyConverter = keyConverter.map(composer)
+        val mappedIncludesCheck = keyIncludesCheck.map(composer)
+        val mappedGuard = composer.compose(guard)
+
+        if (mappedRegion === region
+            && mappedKeyConverter === keyConverter
+            && mappedIncludesCheck === keyIncludesCheck
+            && mappedGuard == guard
+        ) {
+            return this
+        }
+
+        return UMergeUpdateNode(mappedRegion, mappedIncludesCheck, mappedKeyConverter, mappedGuard)
+    }
+
+    override fun toString(): String = "(merge $region)"
 }
 
 /**

--- a/usvm-core/src/main/kotlin/org/usvm/solver/RegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/solver/RegionTranslator.kt
@@ -7,9 +7,11 @@ import org.usvm.UExpr
 import org.usvm.USort
 import org.usvm.memory.UArrayId
 import org.usvm.memory.UMemoryUpdatesVisitor
+import org.usvm.memory.UMergeUpdateNode
 import org.usvm.memory.UPinpointUpdateNode
 import org.usvm.memory.URangedUpdateNode
 import org.usvm.memory.URegionId
+import org.usvm.memory.USymbolicMapId
 import org.usvm.memory.USymbolicMemoryRegion
 import org.usvm.memory.UUpdateNode
 import org.usvm.uctx
@@ -74,7 +76,30 @@ internal class U1DUpdatesTranslator<KeySort : USort, Sort : USort>(
                 when (update.guard) {
                     falseExpr -> previous
                     else -> {
-                        (update as URangedUpdateNode<UArrayId<*, Any?, Sort, *>, Any?, UExpr<KeySort>, Sort>)
+                        (update as URangedUpdateNode<UArrayId<Any?, Sort, *>, Any?, UExpr<KeySort>, Sort>)
+                        val key = mkFreshConst("k", previous.sort.domain)
+
+                        val from = update.region
+
+                        val keyMapper = from.regionId.keyMapper(exprTranslator)
+                        val convertedKey = keyMapper(update.keyConverter.convert(key))
+                        val isInside = update.includesSymbolically(key).translated // already includes guard
+                        val result = from.regionId.instantiate(
+                            from as USymbolicMemoryRegion<Nothing, Any?, Sort>,
+                            convertedKey
+                        ).translated
+                        val ite = mkIte(isInside, result, previous.select(key))
+                        mkArrayLambda(key.decl, ite)
+                    }
+                }
+            }
+
+            is UMergeUpdateNode<*, *, *, *, *, *> -> {
+                @Suppress("UNCHECKED_CAST")
+                when(update.guard){
+                    falseExpr -> previous
+                    else -> {
+                        update as UMergeUpdateNode<USymbolicMapId<Any?, KeySort, *, Sort, *>, Any?, Any?, KeySort, *, Sort>
                         val key = mkFreshConst("k", previous.sort.domain)
 
                         val from = update.region
@@ -141,7 +166,30 @@ internal class U2DUpdatesTranslator<
                 when (update.guard) {
                     falseExpr -> previous
                     else -> {
-                        (update as URangedUpdateNode<UArrayId<*, Any?, Sort, *>, Any?, Pair<UExpr<Key1Sort>, UExpr<Key2Sort>>, Sort>)
+                        (update as URangedUpdateNode<UArrayId<Any?, Sort, *>, Any?, Pair<UExpr<Key1Sort>, UExpr<Key2Sort>>, Sort>)
+                        val key1 = mkFreshConst("k1", previous.sort.domain0)
+                        val key2 = mkFreshConst("k2", previous.sort.domain1)
+
+                        val region = update.region
+                        val keyMapper = region.regionId.keyMapper(exprTranslator)
+                        val convertedKey = keyMapper(update.keyConverter.convert(key1 to key2))
+                        val isInside = update.includesSymbolically(key1 to key2).translated // already includes guard
+                        val result = region.regionId.instantiate(
+                            region as USymbolicMemoryRegion<Nothing, Any?, Sort>,
+                            convertedKey
+                        ).translated
+                        val ite = mkIte(isInside, result, previous.select(key1, key2))
+                        mkArrayLambda(key1.decl, key2.decl, ite)
+                    }
+                }
+            }
+
+            is UMergeUpdateNode<*, *, *, *, *, *> -> {
+                @Suppress("UNCHECKED_CAST")
+                when(update.guard){
+                    falseExpr -> previous
+                    else -> {
+                        update as UMergeUpdateNode<USymbolicMapId<Any?, *, *, Sort, *>, Any?, Any?, *, *, Sort>
                         val key1 = mkFreshConst("k1", previous.sort.domain0)
                         val key2 = mkFreshConst("k2", previous.sort.domain1)
 

--- a/usvm-core/src/test/kotlin/org/usvm/intrinsics/collections/ObjectMapTest.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/intrinsics/collections/ObjectMapTest.kt
@@ -1,0 +1,431 @@
+package org.usvm.intrinsics.collections
+
+import io.ksmt.solver.KSolver
+import io.ksmt.utils.asExpr
+import io.ksmt.utils.uncheckedCast
+import org.junit.jupiter.api.RepeatedTest
+import org.usvm.*
+import org.usvm.intrinsics.collections.SymbolicObjectMapIntrinsics.mkSymbolicObjectMap
+import org.usvm.intrinsics.collections.SymbolicObjectMapIntrinsics.symbolicObjectMapContains
+import org.usvm.intrinsics.collections.SymbolicObjectMapIntrinsics.symbolicObjectMapGet
+import org.usvm.intrinsics.collections.SymbolicObjectMapIntrinsics.symbolicObjectMapMergeInto
+import org.usvm.intrinsics.collections.SymbolicObjectMapIntrinsics.symbolicObjectMapPut
+import org.usvm.intrinsics.collections.SymbolicObjectMapIntrinsics.symbolicObjectMapRemove
+import org.usvm.intrinsics.collections.SymbolicObjectMapIntrinsics.symbolicObjectMapSize
+import org.usvm.model.UModelBase
+import org.usvm.solver.USatResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ObjectMapTest : SymbolicCollectionTestBase() {
+    @Test
+    fun testConcreteMapContains() {
+        val concreteMap = state.mkSymbolicObjectMap(ctx.sizeSort)
+        testMapContains(concreteMap)
+    }
+
+    @Test
+    fun testSymbolicMapContains() {
+        val symbolicMap = ctx.mkRegisterReading(99, ctx.addressSort)
+        testMapContains(symbolicMap)
+    }
+
+    private fun testMapContains(mapRef: UHeapRef) {
+        val concreteKeys = (1..5).map { ctx.mkConcreteHeapRef(it) }
+        val symbolicKeys = (1..5).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+        val storedConcrete = concreteKeys.dropLast(1)
+        val missedConcrete = concreteKeys.last()
+        val storedSymbolic = symbolicKeys.dropLast(1)
+        val missedSymbolic = symbolicKeys.last()
+
+        fillMap(mapRef, storedConcrete + storedSymbolic, startValueIdx = 1)
+
+        checkWithSolver {
+            (storedConcrete + storedSymbolic).forEach { key ->
+                assertImpossible {
+                    val keyContains = state.symbolicObjectMapContains(mapRef, key, ctx.sizeSort)
+                    keyContains eq falseExpr
+                }
+            }
+
+            assertImpossible {
+                val keyContains = state.symbolicObjectMapContains(mapRef, missedConcrete, ctx.sizeSort)
+                keyContains eq trueExpr
+            }
+
+            assertPossible {
+                val keyContains = state.symbolicObjectMapContains(mapRef, missedSymbolic, ctx.sizeSort)
+                keyContains eq falseExpr
+            }
+        }
+
+        val removeConcrete = storedConcrete.first()
+        val removeSymbolic = storedSymbolic.first()
+        val removedKeys = listOf(removeConcrete, removeSymbolic)
+        removedKeys.forEach { key ->
+            state.symbolicObjectMapRemove(mapRef, key, ctx.sizeSort)
+        }
+
+        checkWithSolver {
+            removedKeys.forEach { key ->
+                assertImpossible {
+                    val keyContains = state.symbolicObjectMapContains(mapRef, key, ctx.sizeSort)
+                    keyContains eq trueExpr
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testConcreteMapContainsComposition() {
+        val concreteMap = state.mkSymbolicObjectMap(ctx.sizeSort)
+        testMapContainsComposition(concreteMap)
+    }
+
+    @Test
+    fun testSymbolicMapContainsComposition() {
+        val symbolicMap = ctx.mkRegisterReading(99, ctx.addressSort)
+        testMapContainsComposition(symbolicMap)
+    }
+
+    private fun testMapContainsComposition(mapRef: UHeapRef) {
+        val concreteKeys = (1..5).map { ctx.mkConcreteHeapRef(it) }
+        val symbolicKeys = (1..5).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+        val otherSymbolicKey = ctx.mkRegisterReading(symbolicKeys.size + 1, ctx.addressSort)
+
+        fillMap(mapRef, concreteKeys + symbolicKeys, startValueIdx = 1)
+
+        val otherKeyContains = state.symbolicObjectMapContains(mapRef, otherSymbolicKey, ctx.sizeSort)
+        state.pathConstraints += otherKeyContains
+        state.pathConstraints += ctx.mkNot(ctx.mkEq(mapRef, ctx.nullRef))
+
+        val result = uSolver.checkWithSoftConstraints(state.pathConstraints)
+        assertIs<USatResult<UModelBase<Field, Type>>>(result)
+
+        assertEquals(ctx.trueExpr, result.model.eval(otherKeyContains))
+
+        val removedKeys = setOf(concreteKeys.first(), symbolicKeys.first(), otherSymbolicKey)
+        removedKeys.forEach { key ->
+            state.symbolicObjectMapRemove(mapRef, key, ctx.sizeSort)
+        }
+
+        val removedKeysValues = removedKeys.mapTo(hashSetOf()) { result.model.eval(it) }
+        (concreteKeys + symbolicKeys + otherSymbolicKey).forEach { key ->
+            val keyContains = state.symbolicObjectMapContains(mapRef, key, ctx.sizeSort)
+            val keyContainsValue = result.model.eval(keyContains)
+            val keyValue = result.model.eval(key)
+
+            val expectedResult = ctx.mkBool(keyValue !in removedKeysValues)
+            assertEquals(expectedResult, keyContainsValue)
+        }
+    }
+
+    @Test
+    fun testConcreteMapSize() {
+        val concreteMap = state.mkSymbolicObjectMap(ctx.sizeSort)
+        testMapSize(concreteMap) { size, lowerBound, upperBound ->
+            assertPossible { size eq upperBound }
+            assertPossible { size eq lowerBound }
+            assertImpossible {
+                mkBvSignedLessExpr(size, lowerBound) or mkBvSignedGreaterExpr(size, upperBound)
+            }
+        }
+    }
+
+    @Test
+    fun testSymbolicMapSize() {
+        val symbolicMap = ctx.mkRegisterReading(99, ctx.addressSort)
+        testMapSize(symbolicMap) { size, lowerBound, upperBound ->
+            assertPossible { size eq lowerBound }
+            assertPossible { size eq upperBound }
+        }
+    }
+
+    private fun testMapSize(mapRef: UHeapRef, checkSizeBounds: KSolver<*>.(USizeExpr, USizeExpr, USizeExpr) -> Unit) {
+        val concreteKeys = (1..5).map { ctx.mkConcreteHeapRef(it) }
+        val symbolicKeys = (1..5).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+
+        fillMap(mapRef, concreteKeys + symbolicKeys, startValueIdx = 1)
+
+        checkWithSolver {
+            val sizeLowerBound = ctx.mkSizeExpr(concreteKeys.size + 1) // +1 for at least one symbolic key
+            val sizeUpperBound = ctx.mkSizeExpr(concreteKeys.size + symbolicKeys.size)
+
+            val actualSize = state.symbolicObjectMapSize(mapRef, ctx.sizeSort)
+
+            checkSizeBounds(actualSize, sizeLowerBound, sizeUpperBound)
+        }
+
+        val removedKeys = setOf(concreteKeys.first(), symbolicKeys.first())
+        removedKeys.forEach { key ->
+            state.symbolicObjectMapRemove(mapRef, key, ctx.sizeSort)
+        }
+
+        checkWithSolver {
+            /**
+             * Size lower bound before remove: concrete size + 1
+             * where we add 1 for at least one symbolic key
+             *
+             * Size after remove is concrete -1 since we remove 1 concrete key and one symbolic.
+             * */
+            val minKeySize = concreteKeys.size - 1
+            val sizeLowerBound = ctx.mkSizeExpr(minKeySize)
+            val sizeUpperBound = ctx.mkSizeExpr(concreteKeys.size + symbolicKeys.size - removedKeys.size)
+
+            val actualSize = state.symbolicObjectMapSize(mapRef, ctx.sizeSort)
+
+            checkSizeBounds(actualSize, sizeLowerBound, sizeUpperBound)
+        }
+    }
+
+    @Test
+    fun testMapMergeSymbolicIntoConcrete() = with(state.memory.heap) {
+        val concreteMap = state.mkSymbolicObjectMap(ctx.sizeSort)
+        val symbolicMap = ctx.mkRegisterReading(99, ctx.addressSort)
+
+        testMapMerge(concreteMap, symbolicMap)
+    }
+
+    @Test
+    fun testMapMergeConcreteIntoSymbolic() = with(state.memory.heap) {
+        val concreteMap = state.mkSymbolicObjectMap(ctx.sizeSort)
+        val symbolicMap = ctx.mkRegisterReading(99, ctx.addressSort)
+
+        testMapMerge(concreteMap, symbolicMap)
+    }
+
+    @Test
+    fun testMapMergeConcreteIntoConcrete() = with(state.memory.heap) {
+        val concreteMap0 = state.mkSymbolicObjectMap(ctx.sizeSort)
+        val concreteMap1 = state.mkSymbolicObjectMap(ctx.sizeSort)
+
+        testMapMerge(concreteMap0, concreteMap1)
+    }
+
+    @Test
+    fun testMapMergeSymbolicIntoSymbolic() = with(state.memory.heap) {
+        val symbolicMap0 = ctx.mkRegisterReading(99, ctx.addressSort)
+        val symbolicMap1 = ctx.mkRegisterReading(999, ctx.addressSort)
+
+        testMapMerge(symbolicMap0, symbolicMap1)
+    }
+
+    private fun testMapMerge(mergeTarget: UHeapRef, otherMap: UHeapRef) {
+        val overlapConcreteKeys = (1..3).map { ctx.mkConcreteHeapRef(it) }
+        val nonOverlapConcreteKeys0 = (11..13).map { ctx.mkConcreteHeapRef(it) }
+        val nonOverlapConcreteKeys1 = (21..23).map { ctx.mkConcreteHeapRef(it) }
+
+        val overlapSymbolicKeys = (31..33).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+        val nonOverlapSymbolicKeys0 = (41..43).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+        val nonOverlapSymbolicKeys1 = (51..53).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+
+        val tgtMapKeys = listOf(
+            overlapConcreteKeys,
+            nonOverlapConcreteKeys0,
+            overlapSymbolicKeys,
+            nonOverlapSymbolicKeys0
+        ).flatten()
+
+        val otherMapKeys = listOf(
+            overlapConcreteKeys,
+            nonOverlapConcreteKeys1,
+            overlapSymbolicKeys,
+            nonOverlapSymbolicKeys1
+        ).flatten()
+
+        val removedKeys = setOf(
+            nonOverlapConcreteKeys0.first(),
+            nonOverlapConcreteKeys1.first()
+        )
+
+        val tgtValues = fillMap(mergeTarget, tgtMapKeys, 256)
+        val otherValues = fillMap(otherMap, otherMapKeys, 65536)
+
+        for (key in removedKeys) {
+            state.symbolicObjectMapRemove(mergeTarget, key, ctx.sizeSort)
+            state.symbolicObjectMapRemove(otherMap, key, ctx.sizeSort)
+        }
+
+        state.symbolicObjectMapMergeInto(mergeTarget, otherMap, ctx.sizeSort)
+
+        val mergedContains0 = tgtMapKeys.map { state.symbolicObjectMapContains(mergeTarget, it, ctx.sizeSort) }
+        val mergedContains1 = otherMapKeys.map { state.symbolicObjectMapContains(mergeTarget, it, ctx.sizeSort) }
+
+        val mergedValues0 = tgtMapKeys.map { state.symbolicObjectMapGet(mergeTarget, it, ctx.sizeSort) }
+        val mergedValues1 = otherMapKeys.map { state.symbolicObjectMapGet(mergeTarget, it, ctx.sizeSort) }
+
+        mergedContains0.forEach { checkNoConcreteHeapRefs(it) }
+        mergedContains1.forEach { checkNoConcreteHeapRefs(it) }
+
+        mergedValues0.forEach { checkNoConcreteHeapRefs(it) }
+        mergedValues1.forEach { checkNoConcreteHeapRefs(it) }
+
+        checkWithSolver {
+            val mergedNonOverlapKeys = listOf(
+                nonOverlapConcreteKeys0,
+                nonOverlapConcreteKeys1,
+                nonOverlapSymbolicKeys0,
+                nonOverlapSymbolicKeys1
+            ).flatten() - removedKeys
+
+            for (key in mergedNonOverlapKeys) {
+                val keyContains = state.symbolicObjectMapContains(mergeTarget, key, ctx.sizeSort)
+                assertPossible { keyContains eq trueExpr }
+
+                val storedValue = tgtValues[key] ?: otherValues[key] ?: error("$key was not stored")
+                val actualValue: USizeExpr = state.symbolicObjectMapGet(mergeTarget, key, ctx.sizeSort).uncheckedCast()
+                assertPossible { storedValue eq actualValue }
+            }
+
+            for (key in removedKeys) {
+                val keyContains = state.symbolicObjectMapContains(mergeTarget, key, ctx.sizeSort)
+                assertPossible { keyContains eq falseExpr }
+            }
+
+            val overlapKeys = listOf(
+                overlapConcreteKeys,
+                overlapSymbolicKeys
+            ).flatten()
+
+            for (key in overlapKeys) {
+                val keyContains = state.symbolicObjectMapContains(mergeTarget, key, ctx.sizeSort)
+                assertPossible { keyContains eq trueExpr }
+
+                val storedV1 = tgtValues.getValue(key)
+                val storedV2 = otherValues.getValue(key)
+                val actualValue: USizeExpr = state.symbolicObjectMapGet(mergeTarget, key, ctx.sizeSort).uncheckedCast()
+
+                assertPossible {
+                    (actualValue eq storedV1) or (actualValue eq storedV2)
+                }
+            }
+        }
+    }
+
+    @RepeatedTest(10) // Use repeated test since it may randomly fail on some models
+    fun testMapMergeSymbolicIntoConcreteComposition() = with(state.memory.heap) {
+        val concreteMap = state.mkSymbolicObjectMap(ctx.sizeSort)
+        val symbolicMap = ctx.mkRegisterReading(99, ctx.addressSort)
+
+        testMapMergeComposition(concreteMap, symbolicMap)
+    }
+
+    @RepeatedTest(10) // Use repeated test since it may randomly fail on some models
+    fun testMapMergeConcreteIntoSymbolicComposition() = with(state.memory.heap) {
+        val concreteMap = state.mkSymbolicObjectMap(ctx.sizeSort)
+        val symbolicMap = ctx.mkRegisterReading(99, ctx.addressSort)
+
+        testMapMergeComposition(concreteMap, symbolicMap)
+    }
+
+    @RepeatedTest(10) // Use repeated test since it may randomly fail on some models
+    fun testMapMergeConcreteIntoConcreteComposition() = with(state.memory.heap) {
+        val concreteMap0 = state.mkSymbolicObjectMap(ctx.sizeSort)
+        val concreteMap1 = state.mkSymbolicObjectMap(ctx.sizeSort)
+
+        testMapMergeComposition(concreteMap0, concreteMap1)
+    }
+
+    @RepeatedTest(10) // Use repeated test since it may randomly fail on some models
+    fun testMapMergeSymbolicIntoSymbolicComposition() = with(state.memory.heap) {
+        val symbolicMap0 = ctx.mkRegisterReading(99, ctx.addressSort)
+        val symbolicMap1 = ctx.mkRegisterReading(999, ctx.addressSort)
+
+        testMapMergeComposition(symbolicMap0, symbolicMap1)
+    }
+
+    private fun testMapMergeComposition(mergeTarget: UHeapRef, otherMap: UHeapRef) {
+        val overlapConcreteKeys = (1..3).map { ctx.mkConcreteHeapRef(it) }
+        val nonOverlapConcreteKeys0 = (11..13).map { ctx.mkConcreteHeapRef(it) }
+        val nonOverlapConcreteKeys1 = (21..23).map { ctx.mkConcreteHeapRef(it) }
+
+        val overlapSymbolicKeys = (31..33).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+        val nonOverlapSymbolicKeys0 = (41..43).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+        val nonOverlapSymbolicKeys1 = (51..53).map { ctx.mkRegisterReading(it, ctx.addressSort) }
+
+        val tgtMapKeys = listOf(
+            overlapConcreteKeys,
+            nonOverlapConcreteKeys0,
+            overlapSymbolicKeys,
+            nonOverlapSymbolicKeys0
+        ).flatten()
+
+        val otherMapKeys = listOf(
+            overlapConcreteKeys,
+            nonOverlapConcreteKeys1,
+            overlapSymbolicKeys,
+            nonOverlapSymbolicKeys1
+        ).flatten()
+
+        val removedKeys = setOf(
+            nonOverlapConcreteKeys0.first(),
+            nonOverlapConcreteKeys1.first()
+        )
+
+        val tgtValues = fillMap(mergeTarget, tgtMapKeys, 256)
+        val otherValues = fillMap(otherMap, otherMapKeys, 65536)
+
+        for (key in removedKeys) {
+            state.symbolicObjectMapRemove(mergeTarget, key, ctx.sizeSort)
+            state.symbolicObjectMapRemove(otherMap, key, ctx.sizeSort)
+        }
+
+        state.symbolicObjectMapMergeInto(mergeTarget, otherMap, ctx.sizeSort)
+
+        val otherSymbolicKey = ctx.mkRegisterReading(111, ctx.addressSort)
+        val otherKeyContains = state.symbolicObjectMapContains(mergeTarget, otherSymbolicKey, ctx.sizeSort)
+
+        state.pathConstraints += otherKeyContains
+        state.pathConstraints += ctx.mkNot(ctx.mkEq(mergeTarget, ctx.nullRef))
+        state.pathConstraints += ctx.mkNot(ctx.mkEq(otherMap, ctx.nullRef))
+
+        val result = uSolver.checkWithSoftConstraints(state.pathConstraints)
+        assertIs<USatResult<UModelBase<Field, Type>>>(result)
+
+        assertEquals(ctx.trueExpr, result.model.eval(otherKeyContains))
+
+        val allRemovedKeys = removedKeys + setOf(
+            nonOverlapConcreteKeys0.last(), nonOverlapConcreteKeys1.last(), otherSymbolicKey
+        )
+        allRemovedKeys.forEach { key ->
+            state.symbolicObjectMapRemove(mergeTarget, key, ctx.sizeSort)
+        }
+
+        val removedKeysValues = allRemovedKeys.mapTo(hashSetOf()) { result.model.eval(it) }
+
+        // All stored values are unique
+        val storedValuesKeys = (tgtValues.map { it.value to it.key } + otherValues.map { it.value to it.key }).toMap()
+        assertEquals(tgtValues.size + otherValues.size, storedValuesKeys.size)
+
+        (tgtMapKeys + otherMapKeys + otherSymbolicKey).forEach { key ->
+            val keyContains = state.symbolicObjectMapContains(mergeTarget, key, ctx.sizeSort)
+            val keyContainsValue = result.model.eval(keyContains)
+            val keyValue = result.model.eval(key)
+
+            val expectedResult = ctx.mkBool(keyValue !in removedKeysValues)
+            assertEquals(expectedResult, keyContainsValue)
+
+            if (keyContainsValue.isTrue) {
+                val mapValue = state.symbolicObjectMapGet(mergeTarget, key, ctx.sizeSort).asExpr(ctx.sizeSort)
+                val actualValue = result.model.eval(mapValue)
+                val expectedKey = storedValuesKeys.getValue(actualValue)
+                val expectedKeyValue = result.model.eval(expectedKey)
+                assertEquals(expectedKeyValue, keyValue)
+            }
+        }
+    }
+
+    private fun fillMap(mapRef: UHeapRef, keys: List<UHeapRef>, startValueIdx: Int) = with(state) {
+        keys.mapIndexed { index, key ->
+            val value = ctx.mkSizeExpr(index + startValueIdx)
+            symbolicObjectMapPut(
+                mapRef,
+                key,
+                ctx.sizeSort,
+                value
+            )
+            key to value
+        }.toMap(LinkedHashMap()) // insertion order is important
+    }
+}

--- a/usvm-core/src/test/kotlin/org/usvm/intrinsics/collections/SymbolicCollectionTestBase.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/intrinsics/collections/SymbolicCollectionTestBase.kt
@@ -1,0 +1,89 @@
+package org.usvm.intrinsics.collections
+
+import io.ksmt.solver.KSolver
+import io.ksmt.solver.KSolverStatus
+import io.ksmt.solver.z3.KZ3Solver
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.BeforeEach
+import org.usvm.*
+import org.usvm.constraints.UPathConstraints
+import org.usvm.memory.UMemoryBase
+import org.usvm.model.buildTranslatorAndLazyDecoder
+import org.usvm.solver.UExprTranslator
+import org.usvm.solver.USoftConstraintsProvider
+import org.usvm.solver.USolverBase
+import kotlin.test.assertEquals
+
+abstract class SymbolicCollectionTestBase {
+    lateinit var ctx: UContext
+    lateinit var pathConstraints: UPathConstraints<Type>
+    lateinit var memory: UMemoryBase<Field, Type, Any?>
+    lateinit var state: StateStub
+    lateinit var translator: UExprTranslator<Field, Type>
+    lateinit var uSolver: USolverBase<Field, Type, Any?>
+
+    @BeforeEach
+    fun initializeContext() {
+        val components: UComponents<*, *, *> = mockk()
+        every { components.mkTypeSystem(any()) } returns mockk()
+
+        ctx = UContext(components)
+        pathConstraints = UPathConstraints(ctx)
+        memory = UMemoryBase(ctx, pathConstraints.typeConstraints)
+        state = StateStub(ctx, pathConstraints, memory)
+
+        val softConstraintProvider = USoftConstraintsProvider<Field, Type>(ctx)
+        val (translator, decoder) = buildTranslatorAndLazyDecoder<Field, Type, Any?>(ctx)
+        this.translator = translator
+        uSolver = USolverBase(ctx, KZ3Solver(ctx), translator, decoder, softConstraintProvider)
+    }
+
+    class StateStub(
+        ctx: UContext,
+        pathConstraints: UPathConstraints<Type>,
+        memory: UMemoryBase<Field, Type, Any?>
+    ) : UState<Type, Field, Any?, Any?>(
+        ctx, UCallStack(),
+        pathConstraints, memory, emptyList(), persistentListOf()
+    ) {
+        override fun clone(newConstraints: UPathConstraints<Type>?): UState<Type, Field, Any?, Any?> {
+            error("Unsupported")
+        }
+    }
+
+    fun checkNoConcreteHeapRefs(expr: UExpr<*>) {
+        // Translator throws exception if concrete ref occurs
+        translator.translate(expr)
+    }
+
+    inline fun checkWithSolver(body: KSolver<*>.() -> Unit) {
+        KZ3Solver(ctx).use { solver ->
+            solver.body()
+        }
+    }
+
+    fun KSolver<*>.assertPossible(mkCheck: UContext.() -> UBoolExpr) =
+        assertStatus(KSolverStatus.SAT) { mkCheck() }
+
+    fun KSolver<*>.assertImpossible(mkCheck: UContext.() -> UBoolExpr) =
+        assertStatus(KSolverStatus.UNSAT) { mkCheck() }
+
+    fun KSolver<*>.assertStatus(status: KSolverStatus, mkCheck: UContext.() -> UBoolExpr) = try {
+        push()
+
+        val expr = ctx.mkCheck()
+        val solverExpr = translator.translate(expr)
+
+        assert(solverExpr)
+
+        val actualStatus = check()
+        if (status != actualStatus){
+            println()
+        }
+        assertEquals(status, actualStatus)
+    } finally {
+        pop()
+    }
+}

--- a/usvm-core/src/test/kotlin/org/usvm/intrinsics/collections/SymbolicListTest.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/intrinsics/collections/SymbolicListTest.kt
@@ -1,0 +1,201 @@
+package org.usvm.intrinsics.collections
+
+import io.ksmt.solver.KSolver
+import io.ksmt.utils.uncheckedCast
+import org.usvm.UContext
+import org.usvm.UHeapRef
+import org.usvm.USizeExpr
+import org.usvm.intrinsics.collections.SymbolicListIntrinsics.mkSymbolicList
+import org.usvm.intrinsics.collections.SymbolicListIntrinsics.symbolicListAdd
+import org.usvm.intrinsics.collections.SymbolicListIntrinsics.symbolicListGet
+import org.usvm.intrinsics.collections.SymbolicListIntrinsics.symbolicListInsert
+import org.usvm.intrinsics.collections.SymbolicListIntrinsics.symbolicListRemove
+import org.usvm.intrinsics.collections.SymbolicListIntrinsics.symbolicListSet
+import org.usvm.intrinsics.collections.SymbolicListIntrinsics.symbolicListSize
+import kotlin.test.Test
+
+class SymbolicListTest : SymbolicCollectionTestBase() {
+
+    @Test
+    fun testConcreteListValues() {
+        val concreteList = state.mkSymbolicList(ctx.sizeSort)
+        testListValues(concreteList)
+    }
+
+    @Test
+    fun testSymbolicListValues() {
+        val symbolicList = ctx.mkRegisterReading(99, ctx.addressSort)
+        testListValues(symbolicList)
+    }
+
+    private fun testListValues(listRef: UHeapRef) {
+        val initialSize = state.symbolicListSize(listRef, ctx.sizeSort)
+
+        val listValues = (1..5).mapTo(mutableListOf()) { ctx.mkSizeExpr(it) }
+        listValues.forEach {
+            state.symbolicListAdd(listRef, ctx.sizeSort, it)
+        }
+
+        checkValues(listRef, listValues, initialSize)
+
+        val modifiedIdx = listValues.size / 2
+        val modifiedValue = ctx.mkSizeExpr(42)
+        listValues[modifiedIdx] = modifiedValue
+        val modifiedListIdx = ctx.mkBvAddExpr(initialSize, ctx.mkSizeExpr(modifiedIdx))
+        state.symbolicListSet(listRef, ctx.sizeSort, modifiedListIdx, modifiedValue)
+
+        checkValues(listRef, listValues, initialSize)
+
+        val removeIdx = listValues.size / 2
+        listValues.removeAt(removeIdx)
+        val removeListIdx = ctx.mkBvAddExpr(initialSize, ctx.mkSizeExpr(removeIdx))
+        state.symbolicListRemove(listRef, ctx.sizeSort, removeListIdx)
+
+        checkValues(listRef, listValues, initialSize)
+
+        val insertIdx = listValues.size / 2
+        val insertValue = ctx.mkSizeExpr(17)
+        listValues.add(insertIdx, insertValue)
+        val insertListIdx = ctx.mkBvAddExpr(initialSize, ctx.mkSizeExpr(removeIdx))
+        state.symbolicListInsert(listRef, ctx.sizeSort, insertListIdx, insertValue)
+
+        checkValues(listRef, listValues, initialSize)
+    }
+
+    @Test
+    fun testConcreteListBoundModification() {
+        val concreteList = state.mkSymbolicList(ctx.sizeSort)
+        testListBoundModification(concreteList)
+    }
+
+    @Test
+    fun testSymbolicListBoundModification() {
+        val symbolicList = ctx.mkRegisterReading(99, ctx.addressSort)
+        testListBoundModification(symbolicList)
+    }
+
+    private fun testListBoundModification(listRef: UHeapRef) {
+        val initialSize = state.symbolicListSize(listRef, ctx.sizeSort)
+
+        val listValues = (1..5).mapTo(mutableListOf()) { ctx.mkSizeExpr(it) }
+        listValues.forEach {
+            state.symbolicListAdd(listRef, ctx.sizeSort, it)
+        }
+
+        checkValues(listRef, listValues, initialSize)
+
+        // remove first
+        listValues.removeAt(0)
+        state.symbolicListRemove(listRef, ctx.sizeSort, initialSize)
+
+        checkValues(listRef, listValues, initialSize)
+
+        // insert first
+        val insertHeadValue = ctx.mkSizeExpr(17)
+        listValues.add(0, insertHeadValue)
+        state.symbolicListInsert(listRef, ctx.sizeSort, initialSize, insertHeadValue)
+
+        checkValues(listRef, listValues, initialSize)
+
+        // remove last
+        listValues.removeAt(listValues.lastIndex)
+        run {
+            val listSize = state.symbolicListSize(listRef, ctx.sizeSort)
+            state.symbolicListRemove(listRef, ctx.sizeSort, ctx.mkBvSubExpr(listSize, ctx.mkSizeExpr(1)))
+        }
+
+        checkValues(listRef, listValues, initialSize)
+
+        // insert last
+        val insertTailValue = ctx.mkSizeExpr(17)
+        listValues.add(listValues.size, insertTailValue)
+        run {
+            val listSize = state.symbolicListSize(listRef, ctx.sizeSort)
+            state.symbolicListInsert(listRef, ctx.sizeSort, listSize, insertTailValue)
+        }
+
+        checkValues(listRef, listValues, initialSize)
+    }
+
+    private fun checkValues(listRef: UHeapRef, values: List<USizeExpr>, initialSize: USizeExpr) {
+        val listValues = values.indices.map { idx ->
+            val listIndex = ctx.mkBvAddExpr(initialSize, ctx.mkSizeExpr(idx))
+            state.symbolicListGet(listRef, listIndex, ctx.sizeSort).uncheckedCast<_, USizeExpr>()
+        }
+        checkWithSolver {
+            values.zip(listValues) { expectedValue, actualValue ->
+                assertImpossible {
+                    mkAnd(
+                        inputListSizeAssumption(initialSize),
+                        actualValue neq expectedValue
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testConcreteListSize() {
+        val concreteList = state.mkSymbolicList(ctx.sizeSort)
+        testListSize(concreteList) { actualSize, expectedSize ->
+            assertImpossible { actualSize neq expectedSize }
+        }
+    }
+
+    @Test
+    fun testSymbolicListSize() {
+        val symbolicList = ctx.mkRegisterReading(99, ctx.addressSort)
+        val initialSize = state.symbolicListSize(symbolicList, ctx.sizeSort)
+
+        testListSize(symbolicList) { actualSize, expectedSize ->
+            assertImpossible {
+                mkAnd(
+                    inputListSizeAssumption(initialSize),
+                    mkBvSignedLessExpr(actualSize, expectedSize)
+                )
+            }
+        }
+    }
+
+    private fun testListSize(listRef: UHeapRef, checkSize: KSolver<*>.(USizeExpr, USizeExpr) -> Unit) {
+        val numValues = 5
+        repeat(numValues) {
+            state.symbolicListAdd(listRef, ctx.sizeSort, ctx.mkSizeExpr(it))
+        }
+
+        checkWithSolver {
+            val actualSize = state.symbolicListSize(listRef, ctx.sizeSort)
+            checkSize(actualSize, ctx.mkSizeExpr(numValues))
+        }
+
+        state.symbolicListInsert(
+            listRef = listRef,
+            elementSort = ctx.sizeSort,
+            index = ctx.mkSizeExpr(0),
+            value = ctx.mkSizeExpr(17)
+        )
+
+        checkWithSolver {
+            val actualSize = state.symbolicListSize(listRef, ctx.sizeSort)
+            checkSize(actualSize, ctx.mkSizeExpr(numValues + 1))
+        }
+
+        state.symbolicListRemove(
+            listRef = listRef,
+            elementSort = ctx.sizeSort,
+            index = ctx.mkSizeExpr(numValues / 2)
+        )
+
+        checkWithSolver {
+            val actualSize = state.symbolicListSize(listRef, ctx.sizeSort)
+            checkSize(actualSize, ctx.mkSizeExpr(numValues))
+        }
+    }
+
+    // Constraint size to avoid overflow
+    private fun UContext.inputListSizeAssumption(size: USizeExpr) =
+        mkAnd(
+            mkBvSignedGreaterOrEqualExpr(size, mkSizeExpr(0)),
+            mkBvSignedLessOrEqualExpr(size, mkSizeExpr(1000)),
+        )
+}

--- a/usvm-core/src/test/kotlin/org/usvm/memory/HeapMemCpyTest.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/memory/HeapMemCpyTest.kt
@@ -1,0 +1,116 @@
+package org.usvm.memory
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.usvm.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HeapMemCpyTest {
+    private lateinit var ctx: UContext
+    private lateinit var heap: URegionHeap<Field, Type>
+    private lateinit var arrayType: Type
+    private lateinit var arrayValueSort: USizeSort
+
+    @BeforeEach
+    fun initializeContext() {
+        val components: UComponents<*, *, *> = mockk()
+        every { components.mkTypeSystem(any()) } returns mockk()
+        ctx = UContext(components)
+        heap = URegionHeap(ctx)
+        arrayType = mockk<Type>()
+        arrayValueSort = ctx.sizeSort
+    }
+
+    @Test
+    fun testMemCopyRemoveIndex() = with(ctx) {
+        val (array, ref) = initializeArray()
+
+        val srcFrom = 4
+        val dstFrom = 3
+        val srcTo = array.size
+        val dstTo = srcTo
+        array.copyInto(
+            destination = array,
+            destinationOffset = dstFrom,
+            startIndex = srcFrom,
+            endIndex = srcTo
+        )
+
+        heap.memcpy(
+            srcRef = ref,
+            dstRef = ref,
+            type = arrayType,
+            elementSort = arrayValueSort,
+            fromSrcIdx = ctx.mkSizeExpr(srcFrom - 2),
+            fromDstIdx = ctx.mkSizeExpr(dstFrom),
+            toDstIdx = ctx.mkSizeExpr(dstTo - 2),
+            guard = ctx.trueExpr
+        )
+
+        checkArrayEquals(ref, array)
+    }
+
+    @Test
+    fun testMemCopyInsertIndex() = with(ctx) {
+        val (array, ref) = initializeArray()
+
+        val srcFrom = 3
+        val dstFrom = 4
+        val srcTo = array.size - 1
+        val dstTo = srcTo
+        array.copyInto(
+            destination = array,
+            destinationOffset = dstFrom,
+            startIndex = srcFrom,
+            endIndex = srcTo
+        )
+
+        heap.memcpy(
+            srcRef = ref,
+            dstRef = ref,
+            type = arrayType,
+            elementSort = arrayValueSort,
+            fromSrcIdx = ctx.mkSizeExpr(srcFrom + 2),
+            fromDstIdx = ctx.mkSizeExpr(dstFrom),
+            toDstIdx = ctx.mkSizeExpr(dstTo),
+            guard = ctx.trueExpr
+        )
+
+        checkArrayEquals(ref, array)
+    }
+
+    private fun initializeArray(): Pair<IntArray, UConcreteHeapRef> {
+        val array = IntArray(10) { it + 1 }
+        val ref = heap.allocateArray(ctx.mkSizeExpr(array.size))
+
+        array.indices.forEach { idx ->
+            heap.writeArrayIndex(
+                ref = ref,
+                index = ctx.mkSizeExpr(idx),
+                type = arrayType,
+                sort = arrayValueSort,
+                value = ctx.mkSizeExpr(array[idx]),
+                guard = ctx.trueExpr
+            )
+        }
+
+        checkArrayEquals(ref, array)
+
+        return array to ref
+    }
+
+    private fun checkArrayEquals(ref: UHeapRef, expected: IntArray){
+        val storedValues = expected.indices.map { idx ->
+            heap.readArrayIndex(
+                ref = ref,
+                index = ctx.mkSizeExpr(idx),
+                arrayType = arrayType,
+                sort = arrayValueSort
+            )
+        }
+
+        assertEquals(expected.map { ctx.mkSizeExpr(it) }, storedValues)
+    }
+}

--- a/usvm-core/src/test/kotlin/org/usvm/model/ModelCompositionTest.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/model/ModelCompositionTest.kt
@@ -34,6 +34,8 @@ class ModelCompositionTest {
             mapOf(),
             mapOf(),
             mapOf(),
+            mapOf(),
+            mapOf(),
         )
 
         val stackModel = URegistersStackEagerModel(concreteNull, mapOf(0 to ctx.mkBv(0), 1 to ctx.mkBv(0), 2 to ctx.mkBv(2)))
@@ -60,6 +62,8 @@ class ModelCompositionTest {
             concreteNull,
             mapOf(),
             mapOf(arrayType to inputArray),
+            mapOf(),
+            mapOf(),
             mapOf(),
         )
 
@@ -104,6 +108,8 @@ class ModelCompositionTest {
             mapOf(),
             mapOf(),
             mapOf(arrayType to inputLength),
+            mapOf(),
+            mapOf(),
         )
 
         val stackModel = URegistersStackEagerModel(
@@ -147,6 +153,8 @@ class ModelCompositionTest {
             mapOf(field to inputField),
             mapOf(),
             mapOf(),
+            mapOf(),
+            mapOf(),
         )
 
         val stackModel = URegistersStackEagerModel(
@@ -175,6 +183,8 @@ class ModelCompositionTest {
     fun testComposeAllocatedArrayWithFalseOverwrite() = with(ctx) {
         val heapEvaluator = UHeapEagerModel<Field, Type>(
             concreteNull,
+            mapOf(),
+            mapOf(),
             mapOf(),
             mapOf(),
             mapOf(),

--- a/usvm-core/src/test/kotlin/org/usvm/solver/TranslationTest.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/solver/TranslationTest.kt
@@ -16,9 +16,12 @@ import org.usvm.UAddressSort
 import org.usvm.UBv32Sort
 import org.usvm.UComponents
 import org.usvm.UContext
+import org.usvm.UExpr
+import org.usvm.UHeapRef
 import org.usvm.memory.UInputToAllocatedKeyConverter
 import org.usvm.memory.UInputToInputKeyConverter
 import org.usvm.memory.URegionHeap
+import org.usvm.memory.USymbolicObjectReferenceMapDescriptor
 import org.usvm.memory.emptyAllocatedArrayRegion
 import org.usvm.memory.emptyInputArrayLengthRegion
 import org.usvm.memory.emptyInputArrayRegion
@@ -299,5 +302,55 @@ class TranslationTest {
         translator.translate(readingExtended)
 
         assertEquals(4, ctx.storeCallCounter)
+    }
+
+    @Test
+    fun testSymbolicMapRefKeyRead() = with(ctx) {
+        val concreteMapRef = heap.allocate()
+        val symbolicMapRef = mkRegisterReading(20, addressSort)
+
+        runSymbolicMapRefKeyReadChecks(concreteMapRef)
+        runSymbolicMapRefKeyReadChecks(symbolicMapRef)
+    }
+
+    private fun runSymbolicMapRefKeyReadChecks(mapRef: UHeapRef) = with(ctx) {
+        val descriptor = USymbolicObjectReferenceMapDescriptor(
+            valueSort = valueFieldDescr.second,
+            defaultValue = mkBv(0)
+        )
+
+        val otherConcreteMapRef = heap.allocate()
+        val otherSymbolicMapRef = mkRegisterReading(10, addressSort)
+
+        val concreteRef0 = heap.allocate()
+        val concreteRef1 = heap.allocate()
+        val concreteRefMissed = heap.allocate()
+
+        val symbolicRef0 = mkRegisterReading(0, addressSort)
+        val symbolicRef1 = mkRegisterReading(1, addressSort)
+        val symbolicRefMissed = mkRegisterReading(2, addressSort)
+
+        var storedValue = 1
+        for (ref in listOf(mapRef, otherConcreteMapRef, otherSymbolicMapRef)) {
+            for (keyRef in listOf(concreteRef0, concreteRef1, symbolicRef0, symbolicRef1)) {
+                heap.writeSymbolicMap(descriptor, ref, keyRef, mkBv(storedValue++), trueExpr)
+            }
+        }
+
+        val concreteValue = heap.readSymbolicMap(descriptor, mapRef, concreteRef0)
+        val concreteMissed = heap.readSymbolicMap(descriptor, mapRef, concreteRefMissed)
+
+        val symbolicValue = heap.readSymbolicMap(descriptor, mapRef, symbolicRef0)
+        val symbolicMissed = heap.readSymbolicMap(descriptor, mapRef, symbolicRefMissed)
+
+        checkNoConcreteHeapRefs(concreteValue)
+        checkNoConcreteHeapRefs(concreteMissed)
+        checkNoConcreteHeapRefs(symbolicValue)
+        checkNoConcreteHeapRefs(symbolicMissed)
+    }
+
+    private fun checkNoConcreteHeapRefs(expr: UExpr<*>) {
+        // Translator throws exception if concrete ref occurs
+        translator.translate(expr)
     }
 }


### PR DESCRIPTION
**Extend heap with `SymbolicMap`**
* works like a symbolic array with an arbitrary key
* provides `copySymbolicMapIndexRange` operation for maps with an `Index` key that acts like a `memcpy` 
* provides `mergeSymbolicMap` that merge one map into another (key union, values overwrite when intersect)

`SymbolicMap` has `Allocated` and `Input` region ids, which are parametrized with `SymbolicMapDescriptor`. This representaion allow extensibility because when a map with a new key sort is required we only need to define a new descriptor. 

**Intrinsics**
* `ObjectMap` --- map with object (reference) keys. Currently, use reference equality and act like a `java.util.IdentityHashMap`
* `List` --- list, dynamic array, vector, etc.
* `Engine` --- allows usvm state manipulation: `assume`, `makeSymbolic`