### PR TITLE
Implement `close` functions for UMachine and USolver classes

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/Machine.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Machine.kt
@@ -6,7 +6,7 @@ package org.usvm
  *
  * @see [run]
  */
-abstract class UMachine<State : UState<*, *, *, *>, Target> {
+abstract class UMachine<State : UState<*, *, *, *>, Target> : AutoCloseable {
     /**
      * The main entry point. Template method for running the machine on a specified [target].
      *

--- a/usvm-core/src/main/kotlin/org/usvm/solver/Solver.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/solver/Solver.kt
@@ -21,7 +21,7 @@ open class UUnsatResult<Model> : USolverResult<Model>
 
 open class UUnknownResult<Model> : USolverResult<Model>
 
-abstract class USolver<in PathCondition, out Model> {
+abstract class USolver<in PathCondition, out Model> : AutoCloseable {
     abstract fun check(pc: PathCondition, useSoftConstraints: Boolean): USolverResult<Model>
 }
 
@@ -135,4 +135,8 @@ open class USolverBase<Field, Type, Method>(
 
     fun emptyModel(): UModelBase<Field, Type> =
         (checkWithSoftConstraints(UPathConstraints(ctx)) as USatResult<UModelBase<Field, Type>>).model
+
+    override fun close() {
+        smtSolver.close()
+    }
 }

--- a/usvm-sample-language/src/main/kotlin/org/usvm/interpreter/SampleMachine.kt
+++ b/usvm-sample-language/src/main/kotlin/org/usvm/interpreter/SampleMachine.kt
@@ -60,4 +60,9 @@ class SampleMachine(
     private fun isInterestingState(state: SampleState): Boolean {
         return state.callStack.isNotEmpty() && state.exceptionRegister == null
     }
+
+    override fun close() {
+        solver.close()
+        ctx.close()
+    }
 }


### PR DESCRIPTION
We forgot to implement `close` functions in UMachine and USolver classes. It caused a bug when analysis never ends due to unreleased native resources in `KYicesSolver` in UMachine.

For now, I made UMachine responsible for closing a solver instance, but later we might change it if we want to make `UComponents` a shared instance between different machines.