### PR TITLE
Allow forks with the same path in random path selector

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/ps/RandomTreePathSelector.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/ps/RandomTreePathSelector.kt
@@ -57,7 +57,10 @@ internal class RandomTreePathSelector<State : UState<*, *, *, Statement, *, Stat
             }
 
             // Leaf if reached
-            val nodeFromThisSelector = currentNode.states.singleOrNull { it in states }
+            // Note that we may have several nodes satisfying the predicate here since
+            // they might be created because of type forks or approximation forks.
+            // In such case, they have the same path but different path constraints.
+            val nodeFromThisSelector = currentNode.states.firstOrNull { it in states }
             if (nodeFromThisSelector != null) {
                 peekedState = nodeFromThisSelector
                 break


### PR DESCRIPTION
We used to have a restriction about a single state created by the random path selector in the same path node. Now we allow many such states due to forks with types and approximations when different states have different path constraints with the same paths.