### PR TITLE
Fix terminated states handling

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/Machine.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Machine.kt
@@ -49,7 +49,7 @@ abstract class UMachine<State> : AutoCloseable {
                     } else {
                         // TODO: distinguish between states terminated by exception (runtime or user) and
                         //  those which just exited
-                        observer.onStateTerminated(forkedState)
+                        observer.onStateTerminated(forkedState, stateReachable = true)
                     }
                 }
 
@@ -57,7 +57,7 @@ abstract class UMachine<State> : AutoCloseable {
                     pathSelector.update(state)
                 } else {
                     pathSelector.remove(state)
-                    observer.onStateTerminated(state)
+                    observer.onStateTerminated(state, stateReachable = stateAlive)
                 }
 
                 if (aliveForkedStates.isNotEmpty()) {

--- a/usvm-core/src/main/kotlin/org/usvm/statistics/CoverageStatistics.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/statistics/CoverageStatistics.kt
@@ -92,7 +92,9 @@ class CoverageStatistics<Method, Statement, State : UState<*, Method, Statement,
     }
 
     // TODO: don't consider coverage of runtime exceptions states
-    override fun onStateTerminated(state: State) {
+    override fun onStateTerminated(state: State, stateReachable: Boolean) {
+        if (!stateReachable) return
+
         for (statement in state.reversedPath) {
             val method = applicationGraph.methodOf(statement)
 

--- a/usvm-core/src/main/kotlin/org/usvm/statistics/CoveredNewStatesCollector.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/statistics/CoveredNewStatesCollector.kt
@@ -16,14 +16,14 @@ class CoveredNewStatesCollector<State>(
 
     private var previousCoverage = coverageStatistics.getTotalCoverage()
 
-    override fun onStateTerminated(state: State) {
+    override fun onStateTerminated(state: State, stateReachable: Boolean) {
         val currentCoverage = coverageStatistics.getTotalCoverage()
         if (isException(state)) {
             mutableCollectedStates.add(state)
             return
         }
 
-        if (currentCoverage > previousCoverage) {
+        if (stateReachable && currentCoverage > previousCoverage) {
             previousCoverage = currentCoverage
             mutableCollectedStates.add(state)
         }

--- a/usvm-core/src/main/kotlin/org/usvm/statistics/TerminatedStateRemover.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/statistics/TerminatedStateRemover.kt
@@ -11,7 +11,7 @@ import org.usvm.UState
  * It costs additional memory, but might be useful for debug purposes.
  */
 class TerminatedStateRemover<State : UState<*, *, *, *, State>> : UMachineObserver<State> {
-    override fun onStateTerminated(state: State) {
+    override fun onStateTerminated(state: State, stateReachable: Boolean) {
         state.pathLocation.states.remove(state)
     }
 }

--- a/usvm-core/src/main/kotlin/org/usvm/statistics/UMachineObserver.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/statistics/UMachineObserver.kt
@@ -8,7 +8,7 @@ interface UMachineObserver<State> {
     /**
      * Called when the execution of the state is terminated (by exception or return).
      */
-    fun onStateTerminated(state: State) { }
+    fun onStateTerminated(state: State, stateReachable: Boolean) { }
 
     /**
      * Called on each symbolic execution step. If the state has forked, [forks] are not empty.
@@ -19,8 +19,8 @@ interface UMachineObserver<State> {
 class CompositeUMachineObserver<State>(private val observers: List<UMachineObserver<State>>) : UMachineObserver<State> {
     constructor(vararg observers: UMachineObserver<State>) : this(observers.toList())
 
-    override fun onStateTerminated(state: State) {
-        observers.forEach { it.onStateTerminated(state) }
+    override fun onStateTerminated(state: State, stateReachable: Boolean) {
+        observers.forEach { it.onStateTerminated(state, stateReachable) }
     }
 
     override fun onState(parent: State, forks: Sequence<State>) {


### PR DESCRIPTION
Don't consider a state covered when it terminated in an `UNSAT` state (e.g. due to an impossible `assert`)