### PR TITLE
Fix tree updates iterator

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/memory/SymbolicCollectionUpdates.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/memory/SymbolicCollectionUpdates.kt
@@ -337,6 +337,7 @@ data class UTreeUpdates<Key, Reg : Region<Reg>, Sort : USort>(
     ) : Iterator<UUpdateNode<Key, Sort>> {
         // A set of values we already emitted by this iterator.
         // Note that it contains ONLY elements that have duplicates by key in the RegionTree.
+        // Reference equality on UUpdateNodes is very important here.
         private val emittedUpdates = hashSetOf<UUpdateNode<Key, Sort>>()
 
         // We can return just `hasNext` value without checking for duplicates since

--- a/usvm-core/src/main/kotlin/org/usvm/memory/UpdateNodes.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/memory/UpdateNodes.kt
@@ -115,11 +115,6 @@ class UPinpointUpdateNode<Key, Sort : USort>(
         return res
     }
 
-    override fun equals(other: Any?): Boolean =
-        other is UPinpointUpdateNode<*, *> && this.key == other.key && this.guard == other.guard
-
-    override fun hashCode(): Int = key.hashCode() * 31 + guard.hashCode() // Ignores value
-
     override fun toString(): String = "{$key <- $value}".takeIf { guard.isTrue } ?: "{$key <- $value | $guard}"
 }
 
@@ -203,15 +198,6 @@ class URangedUpdateNode<CollectionId : USymbolicCollectionId<SrcKey, Sort, Colle
 
         return resultUpdateNode
     }
-
-    // Ignores update
-    override fun equals(other: Any?): Boolean =
-        other is URangedUpdateNode<*, *, *, *> &&
-            this.adapter == other.adapter &&
-            this.guard == other.guard
-
-    // Ignores update
-    override fun hashCode(): Int = adapter.hashCode() * 31 + guard.hashCode()
 
     /**
      * Applies this update node to the [memory] with applying composition via [composer].

--- a/usvm-core/src/test/kotlin/org/usvm/CompositionTest.kt
+++ b/usvm-core/src/test/kotlin/org/usvm/CompositionTest.kt
@@ -363,12 +363,18 @@ internal class CompositionTest {
         val sndComposedExpr = sndComposer.compose(fstArrayIndexReading)
         val fstComposedExpr = fstComposer.compose(sndComposedExpr)
 
-        val expectedRegion = region
-            .write(USymbolicArrayIndex(fstAddress, fstIndex), 1.toBv(), guard = mkTrue())
-            .write(USymbolicArrayIndex(sndAddress, sndIndex), 2.toBv(), guard = mkTrue())
-
         require(fstComposedExpr is UInputArrayReading<*, *>)
-        assert(fstComposedExpr.collection.updates.toList() == expectedRegion.updates.toList())
+
+        val updates = fstComposedExpr.collection.updates.toList()
+        assertEquals(2, updates.size)
+        val update0 = assertIs<UPinpointUpdateNode<USymbolicArrayIndex, USizeSort>>(updates[0])
+        val update1 = assertIs<UPinpointUpdateNode<USymbolicArrayIndex, USizeSort>>(updates[1])
+
+        assertEquals(update0.key, USymbolicArrayIndex(fstAddress, fstIndex))
+        assertEquals(update0.value, 1.toBv())
+
+        assertEquals(update1.key, USymbolicArrayIndex(sndAddress, sndIndex))
+        assertEquals(update1.value, 2.toBv())
     }
 
     @Test

--- a/usvm-util/src/main/kotlin/org/usvm/regions/ProductRegion.kt
+++ b/usvm-util/src/main/kotlin/org/usvm/regions/ProductRegion.kt
@@ -122,4 +122,8 @@ data class ProductRegion<X : Region<X>, Y : Region<Y>>(val products: List<Pair<X
         }
         return ProductRegion(newProducts)
     }
+
+    override fun toString(): String = products.joinToString(prefix = "{", separator = ", ", postfix = "}") { (a , b) ->
+        ("$a X $b").prependIndent("\t")
+    }
 }


### PR DESCRIPTION
Fix a problem, found by @tochilinak, in the tree updates iterator.

## Problem

Suppose, you have such writes to the memory region:
```
{k1 <- v1}{k2 <- v2}{k1 <- v1}
```

The latter update `{k1 <- v1}` will be filtered out, due to `emittedUpdates` hash set. This is because `UPinpountUpdate` has custom `equals` and `hashcode` based on guard and key equality which is incorrect. Now, updates have reference equality `equals`.