### PR TITLE
Fix absence of JcMethodCall in the CFG

### DIFF
--- a/usvm-jvm/src/main/kotlin/org/usvm/machine/JcApplicationGraph.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/machine/JcApplicationGraph.kt
@@ -9,6 +9,7 @@ import org.jacodb.api.ext.toType
 import org.jacodb.impl.features.HierarchyExtensionImpl
 import org.jacodb.impl.features.SyncUsagesExtension
 import org.usvm.statistics.ApplicationGraph
+import org.usvm.util.originalInst
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -19,14 +20,17 @@ class JcApplicationGraph(
 ) : ApplicationGraph<JcMethod, JcInst> {
     private val jcApplicationGraph = JcApplicationGraphImpl(cp, SyncUsagesExtension(HierarchyExtensionImpl(cp), cp))
 
-    override fun predecessors(node: JcInst): Sequence<JcInst> =
-        jcApplicationGraph.predecessors(node)
+    override fun predecessors(node: JcInst): Sequence<JcInst> {
+        return jcApplicationGraph.predecessors(node.originalInst())
+    }
 
-    override fun successors(node: JcInst): Sequence<JcInst> =
-        jcApplicationGraph.successors(node)
+    override fun successors(node: JcInst): Sequence<JcInst> {
+        return jcApplicationGraph.successors(node.originalInst())
+    }
 
-    override fun callees(node: JcInst): Sequence<JcMethod> =
-        jcApplicationGraph.callees(node)
+    override fun callees(node: JcInst): Sequence<JcMethod> {
+        return jcApplicationGraph.callees(node.originalInst())
+    }
 
     override fun callers(method: JcMethod): Sequence<JcInst> =
         jcApplicationGraph.callers(method)
@@ -37,8 +41,9 @@ class JcApplicationGraph(
     override fun exitPoints(method: JcMethod): Sequence<JcInst> =
         jcApplicationGraph.exitPoints(method)
 
-    override fun methodOf(node: JcInst): JcMethod =
-        jcApplicationGraph.methodOf(node)
+    override fun methodOf(node: JcInst): JcMethod {
+        return jcApplicationGraph.methodOf(node.originalInst())
+    }
 
     private val typedMethodsCache = ConcurrentHashMap<JcMethod, JcTypedMethod>()
 

--- a/usvm-jvm/src/main/kotlin/org/usvm/util/Utils.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/util/Utils.kt
@@ -4,12 +4,14 @@ import org.jacodb.api.JcClassOrInterface
 import org.jacodb.api.JcRefType
 import org.jacodb.api.JcType
 import org.jacodb.api.JcTypedField
+import org.jacodb.api.cfg.JcInst
 import org.jacodb.api.ext.findFieldOrNull
 import org.jacodb.api.ext.toType
 import org.usvm.UConcreteHeapRef
 import org.usvm.UExpr
 import org.usvm.USort
 import org.usvm.machine.JcContext
+import org.usvm.machine.JcTransparentInstruction
 import org.usvm.memory.ULValue
 import org.usvm.memory.UWritableMemory
 import org.usvm.uctx
@@ -29,3 +31,5 @@ fun UWritableMemory<*>.write(ref: ULValue<*, *>, value: UExpr<*>) {
 
 internal fun UWritableMemory<JcType>.allocHeapRef(type: JcType, useStaticAddress: Boolean): UConcreteHeapRef =
     if (useStaticAddress) allocStatic(type) else allocConcrete(type)
+
+tailrec fun JcInst.originalInst(): JcInst = if (this is JcTransparentInstruction) originalInst.originalInst() else this


### PR DESCRIPTION
Since we don't have `JcMethodCall` instructions in the CFG and we add them dynamically, they are absent in statistics and must be processed in some other way. In this request, I make them `transparent` for statistics, so they proxy requests into instructions they `belong` to