### PR TITLE
Store `enumValue.name` in `enumValueName` (not `enumValue.toString()`)

### DIFF
--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/testcase/descriptor/Descriptor2ValueConverter.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/testcase/descriptor/Descriptor2ValueConverter.kt
@@ -111,7 +111,7 @@ class Descriptor2ValueConverter(private val workerClassLoader: ClassLoader) {
 
     private fun `enum`(descriptor: UTestEnumValueDescriptor): Any {
         val klass = descriptor.type.toJavaClass(workerClassLoader)
-        val enumValue = klass.enumConstants.find { it.toString() == descriptor.enumValueName }
+        val enumValue = klass.enumConstants.find { (it as Enum<*>).name == descriptor.enumValueName }
             ?: error("Can't build descriptor for enum")
         for ((jcField, jcFieldDescr) in descriptor.fields) {
             val jField = jcField.toJavaField(workerClassLoader) ?: continue

--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/testcase/descriptor/Value2DescriptorConverter.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/testcase/descriptor/Value2DescriptorConverter.kt
@@ -205,11 +205,11 @@ open class Value2DescriptorConverter(
         )
     }
 
-    private fun `enum`(value: Any, depth: Int): UTestEnumValueDescriptor {
+    private fun `enum`(value: Enum<*>, depth: Int): UTestEnumValueDescriptor {
         val enumValueJcClass = jcClasspath.findClass(value::class.java.name)
         val jcClass = if (!enumValueJcClass.isEnum) enumValueJcClass.superClass!! else enumValueJcClass
         val fields = mutableMapOf<JcField, UTestValueDescriptor>()
-        val enumValueName = value.toString()
+        val enumValueName = value.name
         val jcType = jcClass.toType()
         val uTestEnumValueDescriptor =
             UTestEnumValueDescriptor(jcType, enumValueName, fields, System.identityHashCode(value))


### PR DESCRIPTION
`enumValue.toString()` is not necessarily an invective function, so using it to build descriptors is unsafe. Furthermore, the name of the `enumValueName` property suggests that `enumValue.name` is stored in it, but unexpectedly `enumValue.toString()` is stored in `enumValueName`.