### PR TITLE
Make jvm-instrumentation less platform dependent

### DIFF
--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/InstrumentationProcessRunner.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/InstrumentationProcessRunner.kt
@@ -32,7 +32,7 @@ class InstrumentationProcessRunner(
         testingProjectClasspath: List<String>,
         jcClasspath: JcClasspath,
         instrumentationClassFactory: KClass<JcInstrumenterFactory<out JcInstrumenter>>
-    ) : this(testingProjectClasspath.joinToString(":"), jcClasspath, instrumentationClassFactory)
+    ) : this(testingProjectClasspath.joinToString(File.pathSeparator), jcClasspath, instrumentationClassFactory)
 
     fun isAlive() = this::lifetime.isInitialized && lifetime.isAlive
 

--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/UTestConcreteExecutor.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/UTestConcreteExecutor.kt
@@ -10,6 +10,7 @@ import org.usvm.instrumentation.testcase.api.UTestExecutionResult
 import org.usvm.instrumentation.testcase.descriptor.UTestUnexpectedExecutionBuilder
 import org.usvm.instrumentation.util.InstrumentationModuleConstants
 import org.usvm.instrumentation.util.UTestExecutorInitException
+import java.io.File
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 
@@ -25,7 +26,7 @@ class UTestConcreteExecutor(
         testingProjectClasspath: List<String>,
         jcClasspath: JcClasspath,
         timeout: Duration
-    ) : this(instrumentationClassFactory, testingProjectClasspath.joinToString(":"), jcClasspath, timeout)
+    ) : this(instrumentationClassFactory, testingProjectClasspath.joinToString(File.pathSeparator), jcClasspath, timeout)
 
     private val lifetime = LifetimeDefinition()
 


### PR DESCRIPTION
Choose file path separators depending on the platform, possibly fixes #115 