### PR TITLE
Fix default instrumenter factory class name

### DIFF
--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/agent/Agent.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/agent/Agent.kt
@@ -1,6 +1,6 @@
 package org.usvm.instrumentation.agent
 
-import org.usvm.instrumentation.instrumentation.JcRuntimeTraceInstrumenter
+import org.usvm.instrumentation.instrumentation.JcRuntimeTraceInstrumenterFactory
 import org.usvm.instrumentation.util.InstrumentationModuleConstants
 import java.io.File
 import java.lang.instrument.Instrumentation
@@ -14,8 +14,8 @@ class Agent {
             val collectorsJarPath = InstrumentationModuleConstants.pathToUsvmCollectorsJar
             val collectorsJar = JarFile(File(collectorsJarPath))
             instrumentation.appendToBootstrapClassLoaderSearch(collectorsJar)
-            val instrumenterClassname = arguments ?: JcRuntimeTraceInstrumenter::class.java.name
-            val transformer = ClassTransformer(instrumenterClassname, instrumentation)
+            val instrumenterFactoryClassname = arguments ?: JcRuntimeTraceInstrumenterFactory::class.java.name
+            val transformer = ClassTransformer(instrumenterFactoryClassname, instrumentation)
             instrumentation.addTransformer(transformer)
         }
     }

--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/agent/ClassTransformer.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/agent/ClassTransformer.kt
@@ -9,12 +9,12 @@ import java.lang.instrument.Instrumentation
 import java.security.ProtectionDomain
 
 class ClassTransformer(
-    instrumenterClassName: String,
+    instrumenterFactoryClassName: String,
     val instrumentation: Instrumentation
 ) : ClassFileTransformer {
 
     private val instrumenterFactoryInstance =
-        Class.forName(instrumenterClassName).constructors.first().newInstance() as JcInstrumenterFactory<*>
+        Class.forName(instrumenterFactoryClassName).constructors.first().newInstance() as JcInstrumenterFactory<*>
     private val instrumenterCache = HashMap<String, ByteArray>()
 
     override fun transform(


### PR DESCRIPTION
Fixes the following error that used to happen when running usvm-jvm-instrumentation without arguments:
```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:491)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:503)
Caused by: java.lang.IllegalArgumentException: wrong number of arguments
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.usvm.instrumentation.agent.ClassTransformer.<init>(ClassTransformer.kt:17)
	at org.usvm.instrumentation.agent.Agent$Companion.premain(Agent.kt:19)
	at org.usvm.instrumentation.agent.Agent.premain(Agent.kt)
	... 6 more
```