### PR TITLE
Fix `int` overflow in `TraceCollector.hash()`

### DIFF
--- a/usvm-jvm-instrumentation/src/collectors/java/org/usvm/instrumentation/collector/trace/TraceCollector.java
+++ b/usvm-jvm-instrumentation/src/collectors/java/org/usvm/instrumentation/collector/trace/TraceCollector.java
@@ -76,7 +76,7 @@ public class TraceCollector {
         }
 
         private int hash(long key) {
-            return (int) (key ^ (key >>> 32)) % capacity;
+            return (int) ((key ^ (key >>> 32)) % capacity);
         }
 
         public void add(long key) {


### PR DESCRIPTION
Java interprets `(int) x % capacity` as `((int) x) % capacity`. Therefore, whenever 33-rd bit of `x` is `1`, then `((int) x)` is negative and hence `(int) x % capacity` is also negative and can't be used as an array index.

In the current implementation 5-th byte of `key` stores the lower byte of the `methodId: Long`, meaning that for classes with over 128 methods 33-rd bit of `key` can be `1`, which ultimately causes `jcInstructionCovered()` to fail with `IndexOutOfBoundsException`.