### PR TITLE
Add test for annotation default value instrumentation

### DIFF
--- a/usvm-jvm-instrumentation/src/samples/java/example/AnnotatedMethodClass.java
+++ b/usvm-jvm-instrumentation/src/samples/java/example/AnnotatedMethodClass.java
@@ -1,8 +1,0 @@
-package example;
-
-public class AnnotatedMethodClass {
-    @MyAnnotation
-    public static int getSelfAnnotationCount() throws NoSuchMethodException {
-        return AnnotatedMethodClass.class.getMethod("getSelfAnnotationCount").getAnnotations().length;
-    }
-}

--- a/usvm-jvm-instrumentation/src/samples/java/example/AnnotationsEx.java
+++ b/usvm-jvm-instrumentation/src/samples/java/example/AnnotationsEx.java
@@ -1,0 +1,16 @@
+package example;
+
+public class AnnotationsEx {
+    @MyAnnotation
+    public static int getSelfAnnotationCount() throws NoSuchMethodException {
+        return AnnotationsEx.class.getMethod("getSelfAnnotationCount").getAnnotations().length;
+    }
+
+    @MyAnnotation
+    public static String getAnnotationDefaultValue() throws NoSuchMethodException {
+        return AnnotationsEx.class
+                .getMethod("getAnnotationDefaultValue")
+                .getAnnotation(MyAnnotation.class)
+                .x();
+    }
+}

--- a/usvm-jvm-instrumentation/src/samples/java/example/MyAnnotation.java
+++ b/usvm-jvm-instrumentation/src/samples/java/example/MyAnnotation.java
@@ -5,4 +5,5 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MyAnnotation {
+    String x() default "MyAnnotation default value";
 }

--- a/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
+++ b/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
@@ -72,13 +72,25 @@ class ConcreteExecutorTests: UTestConcreteExecutorTest() {
 
     @Test
     fun `annotated method test`() = executeTest {
-        val uTest = UTestCreator.AnnotatedMethodClass.getClassAnnotationCount(jcClasspath)
+        val uTest = UTestCreator.AnnotationsEx.getSelfAnnotationCount(jcClasspath)
         val res = uTestConcreteExecutor.executeAsync(uTest)
         assertIs<UTestExecutionSuccessResult>(res)
         val result = res.result
         assertNotNull(result)
         assertIs<UTestConstantDescriptor.Int>(result)
         assertEquals(1, result.value)
+    }
+
+    @Test
+    @Disabled
+    fun `annotation default value test`() = executeTest {
+        val uTest = UTestCreator.AnnotationsEx.getAnnotationDefaultValue(jcClasspath)
+        val res = uTestConcreteExecutor.executeAsync(uTest)
+        assertIs<UTestExecutionSuccessResult>(res)
+        val result = res.result
+        assertNotNull(result)
+        assertIs<UTestConstantDescriptor.String>(result)
+        assertEquals("MyAnnotation default value", result.value)
     }
 
     @Test

--- a/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/util/UTestCreator.kt
+++ b/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/util/UTestCreator.kt
@@ -365,11 +365,20 @@ object UTestCreator {
         }
     }
 
-    object AnnotatedMethodClass {
-        fun getClassAnnotationCount(jcClasspath: JcClasspath): UTest {
-            val jcClass = jcClasspath.findClass<example.AnnotatedMethodClass>()
+    object AnnotationsEx {
+        fun getSelfAnnotationCount(jcClasspath: JcClasspath): UTest {
+            val jcClass = jcClasspath.findClass<example.AnnotationsEx>()
             val jcMethod = jcClass.findDeclaredMethodOrNull("getSelfAnnotationCount")
-                ?: error("Cant find method getSelfAnnotationCount in class AnnotatedMethodClass")
+                ?: error("Cant find method getSelfAnnotationCount in class AnnotationsEx")
+            val instance = UTestNullExpression(jcClass.toType())
+            val statements = emptyList<UTestInst>()
+            return UTest(statements, UTestMethodCall(instance, jcMethod, emptyList()))
+        }
+
+        fun getAnnotationDefaultValue(jcClasspath: JcClasspath): UTest {
+            val jcClass = jcClasspath.findClass<example.AnnotationsEx>()
+            val jcMethod = jcClass.findDeclaredMethodOrNull("getAnnotationDefaultValue")
+                ?: error("Cant find method getAnnotationDefaultValue in class AnnotationsEx")
             val instance = UTestNullExpression(jcClass.toType())
             val statements = emptyList<UTestInst>()
             return UTest(statements, UTestMethodCall(instance, jcMethod, emptyList()))


### PR DESCRIPTION
Instrumenting annotation classes causes default values to get lost. In the added test `UTestExecutionExceptionResult` is returned with the following exception message:
```
example.MyAnnotation missing element x
```
Here are the logs:
```
Debug | ByteBufferAsyncProcessor  | 1:Test worker @coroutine#147 | PAUSE ('Socket not connected') :: {id = usvm-executor-socket/Sender, state = 'Initialized'} 
Debug | Server                    | 99:usvm-executor-socket | usvm-executor-socket: listening /127.0.0.1:33153 
Debug | Server                    | 99:usvm-executor-socket | usvm-executor-socket : connected 
Debug | ByteBufferAsyncProcessor  | 99:usvm-executor-socket | RESUME :: {id = usvm-executor-socket/Sender, state = 'AsyncProcessing'} 

org.opentest4j.AssertionFailedError: Expected value to be of type <org.usvm.instrumentation.testcase.api.UTestExecutionSuccessResult>, actual <class org.usvm.instrumentation.testcase.api.UTestExecutionExceptionResult>.
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:39)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:109)
	at kotlin.test.junit5.JUnit5Asserter.fail(JUnitSupport.kt:56)
	at kotlin.test.Asserter$DefaultImpls.assertTrue(Assertions.kt:652)
	at kotlin.test.junit5.JUnit5Asserter.assertTrue(JUnitSupport.kt:30)
	at kotlin.test.AssertionsKt__AssertionsKt.assertIsOfType(Assertions.kt:122)
	at kotlin.test.AssertionsKt.assertIsOfType(Unknown Source)
	at org.usvm.instrumentation.executor.ConcreteExecutorTests$annotation default value test$1.invokeSuspend(ConcreteExecutorTests.kt:89)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:33)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:284)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at org.usvm.instrumentation.executor.UTestConcreteExecutorTest.executeTest(UTestConcreteExecutorTest.kt:45)
	at org.usvm.instrumentation.executor.ConcreteExecutorTests.annotation default value test(ConcreteExecutorTests.kt:86)
	...
```