### PR TITLE
Improve USVM performance

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val klogging = "1.8.3"
     const val slf4j = "1.6.1"
-    const val ksmt = "0.5.13"
+    const val ksmt = "0.5.21"
     const val collections = "0.3.5"
     const val coroutines = "1.6.4"
     const val jcdb = "1.4.1"

--- a/usvm-core/src/main/kotlin/org/usvm/collection/array/ArrayRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/array/ArrayRegionTranslator.kt
@@ -2,22 +2,19 @@ package org.usvm.collection.array
 
 import io.ksmt.KContext
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KArray2Sort
 import io.ksmt.sort.KArraySort
 import io.ksmt.sort.KBoolSort
 import io.ksmt.utils.mkConst
 import org.usvm.UAddressSort
 import org.usvm.UConcreteHeapAddress
-import org.usvm.UConcreteHeapRef
 import org.usvm.UExpr
-import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.URangedUpdateNode
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
 import org.usvm.memory.USymbolicCollectionId
-import org.usvm.model.UMemory2DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.sizeSort
 import org.usvm.solver.U1DUpdatesTranslator
 import org.usvm.solver.U2DUpdatesTranslator
@@ -54,10 +51,9 @@ class UArrayRegionDecoder<ArrayType, Sort : USort, USizeSort : USort>(
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
-    ) = inputRegionTranslator?.let { UArrayLazyModelRegion(regionId, model, mapping, it) }
+    ) = inputRegionTranslator?.let { UArrayLazyModelRegion(regionId, model, it) }
 }
 
 private class UAllocatedArrayRegionTranslator<ArrayType, Sort : USort, USizeSort : USort>(
@@ -103,10 +99,9 @@ private class UInputArrayRegionTranslator<ArrayType, Sort : USort, USizeSort : U
     }
 
     override fun decodeCollection(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>
+        model: UModelEvaluator<*>
     ): UReadOnlyMemoryRegion<USymbolicArrayIndex<USizeSort>, Sort> =
-        UMemory2DArray(initialValue, model, mapping)
+        model.evalAndCompleteArray2DMemoryRegion(initialValue.decl)
 }
 
 private class UAllocatedArrayUpdatesTranslator<Sort : USort, USizeSort : USort>(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/array/UArrayModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/array/UArrayModelRegion.kt
@@ -1,10 +1,9 @@
 package org.usvm.collection.array
 
-import io.ksmt.solver.KModel
 import org.usvm.UExpr
 import org.usvm.USort
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
 import org.usvm.solver.UCollectionDecoder
 
@@ -21,12 +20,11 @@ abstract class UArrayModelRegion<ArrayType, Sort : USort, USizeSort : USort>(
 
 class UArrayLazyModelRegion<ArrayType, Sort : USort, USizeSort : USort>(
     regionId: UArrayRegionId<ArrayType, Sort, USizeSort>,
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val inputArrayDecoder: UCollectionDecoder<USymbolicArrayIndex<USizeSort>, Sort>
 ) : UArrayModelRegion<ArrayType, Sort, USizeSort>(regionId) {
     override val inputArray: UReadOnlyMemoryRegion<USymbolicArrayIndex<USizeSort>, Sort> by lazy {
-        inputArrayDecoder.decodeCollection(model, addressesMapping)
+        inputArrayDecoder.decodeCollection(model)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/array/length/ArrayLengthRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/array/length/ArrayLengthRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.collection.array.length
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UBoolExpr
 import org.usvm.UConcreteHeapAddress
 import org.usvm.UExpr
@@ -42,7 +42,7 @@ interface UArrayLengthsRegion<ArrayType, USizeSort : USort> : UMemoryRegion<UArr
 internal class UArrayLengthsMemoryRegion<ArrayType, USizeSort : USort>(
     private val sort: USizeSort,
     private val arrayType: ArrayType,
-    private val allocatedLengths: PersistentMap<UConcreteHeapAddress, UExpr<USizeSort>> = persistentMapOf(),
+    private val allocatedLengths: PersistentMap<UConcreteHeapAddress, UExpr<USizeSort>> = persistentHashMapOf(),
     private var inputLengths: UInputArrayLengths<ArrayType, USizeSort>? = null
 ) : UArrayLengthsRegion<ArrayType, USizeSort> {
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/array/length/ArrayLengthRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/array/length/ArrayLengthRegionTranslator.kt
@@ -2,18 +2,16 @@ package org.usvm.collection.array.length
 
 import io.ksmt.KContext
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KArraySort
 import io.ksmt.sort.KBoolSort
 import io.ksmt.utils.mkConst
 import org.usvm.UAddressSort
-import org.usvm.UConcreteHeapRef
 import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.URangedUpdateNode
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
-import org.usvm.model.UMemory1DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.sizeSort
 import org.usvm.solver.U1DUpdatesTranslator
 import org.usvm.solver.UCollectionDecoder
@@ -39,10 +37,9 @@ class UArrayLengthRegionDecoder<ArrayType, USizeSort : USort>(
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
-    ) = inputArrayLengthTranslator?.let { UArrayLengthLazyModelRegion(regionId, model, mapping, it) }
+    ) = inputArrayLengthTranslator?.let { UArrayLengthLazyModelRegion(regionId, model, it) }
 }
 
 private class UInputArrayLengthRegionTranslator<ArrayType, USizeSort : USort>(
@@ -66,10 +63,9 @@ private class UInputArrayLengthRegionTranslator<ArrayType, USizeSort : USort>(
     }
 
     override fun decodeCollection(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>
+        model: UModelEvaluator<*>
     ): UReadOnlyMemoryRegion<UHeapRef, USizeSort> =
-        UMemory1DArray(initialValue, model, mapping)
+        model.evalAndCompleteArray1DMemoryRegion(initialValue.decl)
 }
 
 private class UInputArrayLengthUpdateTranslator<USizeSort : USort>(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/array/length/UArrayLengthModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/array/length/UArrayLengthModelRegion.kt
@@ -1,11 +1,10 @@
 package org.usvm.collection.array.length
 
-import io.ksmt.solver.KModel
 import org.usvm.UExpr
 import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
 import org.usvm.solver.UCollectionDecoder
 
@@ -22,12 +21,11 @@ abstract class UArrayLengthModelRegion<ArrayType, USizeSort : USort>(
 
 class UArrayLengthLazyModelRegion<ArrayType, USizeSort : USort>(
     regionId: UArrayLengthsRegionId<ArrayType, USizeSort>,
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val inputArrayLengthDecoder: UCollectionDecoder<UHeapRef, USizeSort>,
 ) : UArrayLengthModelRegion<ArrayType, USizeSort>(regionId) {
     override val inputArrayLength: UReadOnlyMemoryRegion<UHeapRef, USizeSort> by lazy {
-        inputArrayLengthDecoder.decodeCollection(model, addressesMapping)
+        inputArrayLengthDecoder.decodeCollection(model)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/field/FieldRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/field/FieldRegionTranslator.kt
@@ -2,18 +2,16 @@ package org.usvm.collection.field
 
 import io.ksmt.KContext
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KArraySort
 import io.ksmt.sort.KBoolSort
 import io.ksmt.utils.mkConst
 import org.usvm.UAddressSort
-import org.usvm.UConcreteHeapRef
 import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.URangedUpdateNode
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
-import org.usvm.model.UMemory1DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.solver.U1DUpdatesTranslator
 import org.usvm.solver.UCollectionDecoder
 import org.usvm.solver.UExprTranslator
@@ -38,10 +36,9 @@ class UFieldRegionDecoder<Field, Sort : USort>(
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
-    ) = inputRegionTranslator?.let { UFieldsLazyModelRegion(regionId, model, mapping, it) }
+    ) = inputRegionTranslator?.let { UFieldsLazyModelRegion(regionId, model, it) }
 }
 
 private class UInputFieldRegionTranslator<Field, Sort : USort>(
@@ -64,10 +61,9 @@ private class UInputFieldRegionTranslator<Field, Sort : USort>(
     }
 
     override fun decodeCollection(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>
+        model: UModelEvaluator<*>
     ): UReadOnlyMemoryRegion<UHeapRef, Sort> =
-        UMemory1DArray(initialValue, model, mapping)
+        model.evalAndCompleteArray1DMemoryRegion(initialValue.decl)
 }
 
 private class UInputFieldUpdateTranslator<Sort : USort>(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/field/FieldsRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/field/FieldsRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.collection.field
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UBoolExpr
 import org.usvm.UConcreteHeapAddress
 import org.usvm.UExpr
@@ -39,7 +39,7 @@ interface UFieldsRegion<Field, Sort : USort> : UMemoryRegion<UFieldLValue<Field,
 internal class UFieldsMemoryRegion<Field, Sort : USort>(
     private val sort: Sort,
     private val field: Field,
-    private val allocatedFields: PersistentMap<UConcreteHeapAddress, UExpr<Sort>> = persistentMapOf(),
+    private val allocatedFields: PersistentMap<UConcreteHeapAddress, UExpr<Sort>> = persistentHashMapOf(),
     private var inputFields: UInputFields<Field, Sort>? = null
 ) : UFieldsRegion<Field, Sort> {
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/field/UFieldsModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/field/UFieldsModelRegion.kt
@@ -1,13 +1,11 @@
 package org.usvm.collection.field
 
-import io.ksmt.solver.KModel
 import org.usvm.UExpr
 import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
-import org.usvm.sampleUValue
 import org.usvm.solver.UCollectionDecoder
 
 abstract class UFieldsModelRegion<Field, Sort : USort>(
@@ -23,12 +21,11 @@ abstract class UFieldsModelRegion<Field, Sort : USort>(
 
 class UFieldsLazyModelRegion<Field, Sort : USort>(
     regionId: UFieldsRegionId<Field, Sort>,
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val inputFieldsDecoder: UCollectionDecoder<UHeapRef, Sort>
 ) : UFieldsModelRegion<Field, Sort>(regionId) {
     override val inputFields: UReadOnlyMemoryRegion<UHeapRef, Sort> by lazy {
-        inputFieldsDecoder.decodeCollection(model, addressesMapping)
+        inputFieldsDecoder.decodeCollection(model)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/length/UMapLengthModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/length/UMapLengthModelRegion.kt
@@ -1,11 +1,10 @@
 package org.usvm.collection.map.length
 
-import io.ksmt.solver.KModel
 import org.usvm.UExpr
 import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
 import org.usvm.solver.UCollectionDecoder
 
@@ -22,12 +21,11 @@ abstract class UMapLengthModelRegion<MapType, USizeSort : USort>(
 
 class UMapLengthLazyModelRegion<MapType, USizeSort : USort>(
     regionId: UMapLengthRegionId<MapType, USizeSort>,
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val inputLengthDecoder: UCollectionDecoder<UHeapRef, USizeSort>
 ) : UMapLengthModelRegion<MapType, USizeSort>(regionId) {
     override val inputMapLength: UReadOnlyMemoryRegion<UHeapRef, USizeSort> by lazy {
-        inputLengthDecoder.decodeCollection(model, addressesMapping)
+        inputLengthDecoder.decodeCollection(model)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/length/UMapLengthRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/length/UMapLengthRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.collection.map.length
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UBoolExpr
 import org.usvm.UConcreteHeapAddress
 import org.usvm.UExpr
@@ -43,7 +43,7 @@ interface UMapLengthRegion<MapType, USizeSort : USort> : UMemoryRegion<UMapLengt
 internal class UMapLengthMemoryRegion<MapType, USizeSort : USort>(
     private val sort: USizeSort,
     private val mapType: MapType,
-    private val allocatedLengths: PersistentMap<UConcreteHeapAddress, UExpr<USizeSort>> = persistentMapOf(),
+    private val allocatedLengths: PersistentMap<UConcreteHeapAddress, UExpr<USizeSort>> = persistentHashMapOf(),
     private var inputLengths: UInputMapLength<MapType, USizeSort>? = null
 ) : UMapLengthRegion<MapType, USizeSort> {
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/length/UMapLengthRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/length/UMapLengthRegionTranslator.kt
@@ -2,18 +2,16 @@ package org.usvm.collection.map.length
 
 import io.ksmt.KContext
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KArraySort
 import io.ksmt.sort.KBoolSort
 import io.ksmt.utils.mkConst
 import org.usvm.UAddressSort
-import org.usvm.UConcreteHeapRef
 import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.URangedUpdateNode
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
-import org.usvm.model.UMemory1DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.sizeSort
 import org.usvm.solver.U1DUpdatesTranslator
 import org.usvm.solver.UCollectionDecoder
@@ -39,10 +37,9 @@ class UMapLengthRegionDecoder<MapType, USizeSort : USort>(
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
-    ) = inputRegionTranslator?.let { UMapLengthLazyModelRegion(regionId, model, mapping, it) }
+    ) = inputRegionTranslator?.let { UMapLengthLazyModelRegion(regionId, model, it) }
 }
 
 private class UInputMapLengthRegionTranslator<MapType, USizeSort : USort>(
@@ -66,10 +63,9 @@ private class UInputMapLengthRegionTranslator<MapType, USizeSort : USort>(
     }
 
     override fun decodeCollection(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>
+        model: UModelEvaluator<*>
     ): UReadOnlyMemoryRegion<UHeapRef, USizeSort> =
-        UMemory1DArray(initialValue, model, mapping)
+        model.evalAndCompleteArray1DMemoryRegion(initialValue.decl)
 }
 
 private class UInputMapLengthUpdateTranslator<USizeSort : USort>(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/primitive/UMapModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/primitive/UMapModelRegion.kt
@@ -1,11 +1,10 @@
 package org.usvm.collection.map.primitive
 
-import io.ksmt.solver.KModel
 import org.usvm.UExpr
 import org.usvm.USort
 import org.usvm.collection.map.USymbolicMapKey
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
 import org.usvm.solver.UCollectionDecoder
 import org.usvm.regions.Region
@@ -23,12 +22,11 @@ abstract class UMapModelRegion<MapType, KeySort : USort, ValueSort : USort, Reg 
 
 class UMapLazyModelRegion<MapType, KeySort : USort, ValueSort : USort, Reg : Region<Reg>>(
     regionId: UMapRegionId<MapType, KeySort, ValueSort, Reg>,
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val inputMapDecoder: UCollectionDecoder<USymbolicMapKey<KeySort>, ValueSort>
 ) : UMapModelRegion<MapType, KeySort, ValueSort, Reg>(regionId) {
     override val inputMap: UReadOnlyMemoryRegion<USymbolicMapKey<KeySort>, ValueSort> by lazy {
-        inputMapDecoder.decodeCollection(model, addressesMapping)
+        inputMapDecoder.decodeCollection(model)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/primitive/UMapRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/primitive/UMapRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.collection.map.primitive
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UBoolExpr
 import org.usvm.UExpr
 import org.usvm.UHeapRef
@@ -67,7 +67,7 @@ internal class UMapMemoryRegion<MapType, KeySort : USort, ValueSort : USort, Reg
     private val valueSort: ValueSort,
     private val mapType: MapType,
     private val keyInfo: USymbolicCollectionKeyInfo<UExpr<KeySort>, Reg>,
-    private var allocatedMaps: PersistentMap<UAllocatedMapId<MapType, KeySort, ValueSort, Reg>, UAllocatedMap<MapType, KeySort, ValueSort, Reg>> = persistentMapOf(),
+    private var allocatedMaps: PersistentMap<UAllocatedMapId<MapType, KeySort, ValueSort, Reg>, UAllocatedMap<MapType, KeySort, ValueSort, Reg>> = persistentHashMapOf(),
     private var inputMap: UInputMap<MapType, KeySort, ValueSort, Reg>? = null,
 ) : UMapRegion<MapType, KeySort, ValueSort, Reg> {
     init {

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/primitive/UMapRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/primitive/UMapRegionTranslator.kt
@@ -2,23 +2,20 @@ package org.usvm.collection.map.primitive
 
 import io.ksmt.KContext
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KArray2Sort
 import io.ksmt.sort.KArraySort
 import io.ksmt.sort.KBoolSort
 import io.ksmt.utils.mkConst
 import org.usvm.UAddressSort
 import org.usvm.UConcreteHeapAddress
-import org.usvm.UConcreteHeapRef
 import org.usvm.UExpr
-import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.collection.map.USymbolicMapKey
 import org.usvm.memory.URangedUpdateNode
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
 import org.usvm.memory.USymbolicCollectionId
-import org.usvm.model.UMemory2DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.solver.U1DUpdatesTranslator
 import org.usvm.solver.U2DUpdatesTranslator
 import org.usvm.solver.UCollectionDecoder
@@ -55,10 +52,9 @@ class UMapRegionDecoder<MapType, KeySort : USort, ValueSort : USort, Reg : Regio
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
-    ) = inputRegionTranslator?.let { UMapLazyModelRegion(regionId, model, mapping, it) }
+    ) = inputRegionTranslator?.let { UMapLazyModelRegion(regionId, model, it) }
 }
 
 private class UAllocatedMapTranslator<MapType, KeySort : USort, ValueSort : USort, Reg : Region<Reg>>(
@@ -104,10 +100,9 @@ private class UInputMapTranslator<MapType, KeySort : USort, ValueSort : USort, R
     }
 
     override fun decodeCollection(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>
+        model: UModelEvaluator<*>
     ): UReadOnlyMemoryRegion<USymbolicMapKey<KeySort>, ValueSort> =
-        UMemory2DArray(initialValue, model, mapping)
+        model.evalAndCompleteArray2DMemoryRegion(initialValue.decl)
 }
 
 private class UAllocatedMapUpdatesTranslator<KeySort : USort, ValueSort : USort>(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/ref/URefMapModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/ref/URefMapModelRegion.kt
@@ -1,14 +1,12 @@
 package org.usvm.collection.map.ref
 
-import io.ksmt.solver.KModel
 import org.usvm.UAddressSort
 import org.usvm.UExpr
 import org.usvm.USort
 import org.usvm.collection.map.USymbolicMapKey
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
-import org.usvm.sampleUValue
 import org.usvm.solver.UCollectionDecoder
 
 abstract class URefMapModelRegion<MapType, ValueSort : USort>(
@@ -24,12 +22,11 @@ abstract class URefMapModelRegion<MapType, ValueSort : USort>(
 
 class URefMapLazyModelRegion<MapType, ValueSort : USort>(
     regionId: URefMapRegionId<MapType, ValueSort>,
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val inputMapDecoder: UCollectionDecoder<USymbolicMapKey<UAddressSort>, ValueSort>
 ) : URefMapModelRegion<MapType, ValueSort>(regionId) {
     override val inputMap: UReadOnlyMemoryRegion<USymbolicMapKey<UAddressSort>, ValueSort> by lazy {
-        inputMapDecoder.decodeCollection(model, addressesMapping)
+        inputMapDecoder.decodeCollection(model)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/ref/URefMapRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/ref/URefMapRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.collection.map.ref
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UAddressSort
 import org.usvm.UBoolExpr
 import org.usvm.UConcreteHeapAddress
@@ -73,9 +73,9 @@ internal data class UAllocatedRefMapWithAllocatedKeysId(
 internal class URefMapMemoryRegion<MapType, ValueSort : USort>(
     private val valueSort: ValueSort,
     private val mapType: MapType,
-    private var allocatedMapWithAllocatedKeys: PersistentMap<UAllocatedRefMapWithAllocatedKeysId, UExpr<ValueSort>> = persistentMapOf(),
-    private var inputMapWithAllocatedKeys: PersistentMap<UInputRefMapWithAllocatedKeysId<MapType, ValueSort>, UInputRefMapWithAllocatedKeys<MapType, ValueSort>> = persistentMapOf(),
-    private var allocatedMapWithInputKeys: PersistentMap<UAllocatedRefMapWithInputKeysId<MapType, ValueSort>, UAllocatedRefMapWithInputKeys<MapType, ValueSort>> = persistentMapOf(),
+    private var allocatedMapWithAllocatedKeys: PersistentMap<UAllocatedRefMapWithAllocatedKeysId, UExpr<ValueSort>> = persistentHashMapOf(),
+    private var inputMapWithAllocatedKeys: PersistentMap<UInputRefMapWithAllocatedKeysId<MapType, ValueSort>, UInputRefMapWithAllocatedKeys<MapType, ValueSort>> = persistentHashMapOf(),
+    private var allocatedMapWithInputKeys: PersistentMap<UAllocatedRefMapWithInputKeysId<MapType, ValueSort>, UAllocatedRefMapWithInputKeys<MapType, ValueSort>> = persistentHashMapOf(),
     private var inputMapWithInputKeys: UInputRefMap<MapType, ValueSort>? = null,
 ) : URefMapRegion<MapType, ValueSort> {
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/map/ref/URefMapRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/map/ref/URefMapRegionTranslator.kt
@@ -2,14 +2,12 @@ package org.usvm.collection.map.ref
 
 import io.ksmt.KContext
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KArray2Sort
 import io.ksmt.sort.KArraySort
 import io.ksmt.sort.KBoolSort
 import io.ksmt.utils.mkConst
 import org.usvm.UAddressSort
 import org.usvm.UConcreteHeapAddress
-import org.usvm.UConcreteHeapRef
 import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.collection.map.USymbolicMapKey
@@ -17,7 +15,7 @@ import org.usvm.memory.URangedUpdateNode
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
 import org.usvm.memory.USymbolicCollectionId
-import org.usvm.model.UMemory2DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.solver.U1DUpdatesTranslator
 import org.usvm.solver.U2DUpdatesTranslator
 import org.usvm.solver.UCollectionDecoder
@@ -63,10 +61,9 @@ class URefMapRegionDecoder<MapType, ValueSort : USort>(
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
-    ) = inputRegionTranslator?.let { URefMapLazyModelRegion(regionId, model, mapping, it) }
+    ) = inputRegionTranslator?.let { URefMapLazyModelRegion(regionId, model, it) }
 }
 
 private class UAllocatedRefMapWithInputKeysTranslator<MapType, ValueSort : USort>(
@@ -134,10 +131,9 @@ private class UInputRefMapTranslator<MapType, ValueSort : USort>(
     }
 
     override fun decodeCollection(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>
+        model: UModelEvaluator<*>
     ): UReadOnlyMemoryRegion<USymbolicMapKey<UAddressSort>, ValueSort> =
-        UMemory2DArray(initialValue, model, mapping)
+        model.evalAndCompleteArray2DMemoryRegion(initialValue.decl)
 }
 
 private class UAllocatedRefMapUpdatesTranslator<ValueSort : USort>(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/set/primitive/USetModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/set/primitive/USetModelRegion.kt
@@ -1,7 +1,6 @@
 package org.usvm.collection.set.primitive
 
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KBoolSort
 import org.usvm.UAddressSort
 import org.usvm.UBoolExpr
@@ -11,8 +10,8 @@ import org.usvm.USort
 import org.usvm.collection.set.USetCollectionDecoder
 import org.usvm.isFalse
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
 import org.usvm.model.UMemory2DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
 import org.usvm.regions.Region
 
@@ -45,13 +44,12 @@ abstract class USetModelRegion<SetType, ElementSort : USort, Reg : Region<Reg>>(
 
 class USetLazyModelRegion<SetType, ElementSort : USort, Reg : Region<Reg>>(
     regionId: USetRegionId<SetType, ElementSort, Reg>,
-    model: KModel,
-    addressesMapping: AddressesMapping,
+    model: UModelEvaluator<*>,
     assertions: List<KExpr<KBoolSort>>,
     inputSetDecoder: USetCollectionDecoder<ElementSort>
 ) : USetModelRegion<SetType, ElementSort, Reg>(regionId) {
     override val inputSet: UMemory2DArray<UAddressSort, ElementSort, UBoolSort> by lazy {
-        inputSetDecoder.decodeCollection(model, addressesMapping, assertions)
+        inputSetDecoder.decodeCollection(model, assertions)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/set/primitive/USetRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/set/primitive/USetRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.collection.set.primitive
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UBoolExpr
 import org.usvm.UBoolSort
 import org.usvm.UConcreteHeapAddress
@@ -84,7 +84,7 @@ internal class USetMemoryRegion<SetType, ElementSort : USort, Reg : Region<Reg>>
     private val setType: SetType,
     private val elementSort: ElementSort,
     private val elementInfo: USymbolicCollectionKeyInfo<UExpr<ElementSort>, Reg>,
-    private var allocatedSets: PersistentMap<UAllocatedSetId<SetType, ElementSort, Reg>, UAllocatedSet<SetType, ElementSort, Reg>> = persistentMapOf(),
+    private var allocatedSets: PersistentMap<UAllocatedSetId<SetType, ElementSort, Reg>, UAllocatedSet<SetType, ElementSort, Reg>> = persistentHashMapOf(),
     private var inputSet: UInputSet<SetType, ElementSort, Reg>? = null,
 ) : USetRegion<SetType, ElementSort, Reg> {
     init {

--- a/usvm-core/src/main/kotlin/org/usvm/collection/set/primitive/USetRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/set/primitive/USetRegionTranslator.kt
@@ -1,12 +1,9 @@
 package org.usvm.collection.set.primitive
 
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KBoolSort
 import org.usvm.UBoolSort
-import org.usvm.UConcreteHeapRef
 import org.usvm.UExpr
-import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.collection.set.UAllocatedSetUpdatesTranslator
 import org.usvm.collection.set.UInputSetUpdatesTranslator
@@ -14,6 +11,7 @@ import org.usvm.collection.set.USetCollectionDecoder
 import org.usvm.collection.set.USymbolicSetElement
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
+import org.usvm.model.UModelEvaluator
 import org.usvm.regions.Region
 import org.usvm.solver.UExprTranslator
 import org.usvm.solver.URegionDecoder
@@ -47,11 +45,10 @@ class USetRegionDecoder<SetType, ElementSort : USort, Reg : Region<Reg>>(
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
     ): UReadOnlyMemoryRegion<USetEntryLValue<SetType, ElementSort, Reg>, UBoolSort>? =
-        inputRegionTranslator?.let { USetLazyModelRegion(regionId, model, mapping, assertions, it) }
+        inputRegionTranslator?.let { USetLazyModelRegion(regionId, model, assertions, it) }
 }
 
 private class UAllocatedSetTranslator<SetType, ElementSort : USort, Reg : Region<Reg>>(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/set/ref/URefSetModelRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/set/ref/URefSetModelRegion.kt
@@ -1,7 +1,6 @@
 package org.usvm.collection.set.ref
 
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KBoolSort
 import org.usvm.UAddressSort
 import org.usvm.UBoolExpr
@@ -10,8 +9,8 @@ import org.usvm.UHeapRef
 import org.usvm.collection.set.USetCollectionDecoder
 import org.usvm.isFalse
 import org.usvm.memory.UReadOnlyMemoryRegion
-import org.usvm.model.AddressesMapping
 import org.usvm.model.UMemory2DArray
+import org.usvm.model.UModelEvaluator
 import org.usvm.model.modelEnsureConcreteInputRef
 
 abstract class URefSetModelRegion<SetType>(
@@ -42,13 +41,12 @@ abstract class URefSetModelRegion<SetType>(
 
 class URefSetLazyModelRegion<SetType>(
     regionId: URefSetRegionId<SetType>,
-    model: KModel,
-    addressesMapping: AddressesMapping,
+    model: UModelEvaluator<*>,
     assertions: List<KExpr<KBoolSort>>,
     inputSetDecoder: USetCollectionDecoder<UAddressSort>
 ) : URefSetModelRegion<SetType>(regionId) {
     override val inputSet: UMemory2DArray<UAddressSort, UAddressSort, UBoolSort> by lazy {
-        inputSetDecoder.decodeCollection(model, addressesMapping, assertions)
+        inputSetDecoder.decodeCollection(model, assertions)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/collection/set/ref/URefSetRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/set/ref/URefSetRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.collection.set.ref
 
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UAddressSort
 import org.usvm.UBoolExpr
 import org.usvm.UBoolSort
@@ -82,9 +82,9 @@ interface URefSetRegion<SetType> :
 internal class URefSetMemoryRegion<SetType>(
     private val setType: SetType,
     private val sort: UBoolSort,
-    private var allocatedSetWithAllocatedElements: PersistentMap<UAllocatedRefSetWithAllocatedElementId, UBoolExpr> = persistentMapOf(),
-    private var allocatedSetWithInputElements: PersistentMap<UAllocatedRefSetWithInputElementsId<SetType>, UAllocatedRefSetWithInputElements<SetType>> = persistentMapOf(),
-    private var inputSetWithAllocatedElements: PersistentMap<UInputRefSetWithAllocatedElementsId<SetType>, UInputRefSetWithAllocatedElements<SetType>> = persistentMapOf(),
+    private var allocatedSetWithAllocatedElements: PersistentMap<UAllocatedRefSetWithAllocatedElementId, UBoolExpr> = persistentHashMapOf(),
+    private var allocatedSetWithInputElements: PersistentMap<UAllocatedRefSetWithInputElementsId<SetType>, UAllocatedRefSetWithInputElements<SetType>> = persistentHashMapOf(),
+    private var inputSetWithAllocatedElements: PersistentMap<UInputRefSetWithAllocatedElementsId<SetType>, UInputRefSetWithAllocatedElements<SetType>> = persistentHashMapOf(),
     private var inputSetWithInputElements: UInputRefSetWithInputElements<SetType>? = null
 ) : URefSetRegion<SetType> {
     private fun updateAllocatedSetWithAllocatedElements(

--- a/usvm-core/src/main/kotlin/org/usvm/collection/set/ref/URefSetRegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/collection/set/ref/URefSetRegionTranslator.kt
@@ -1,11 +1,9 @@
 package org.usvm.collection.set.ref
 
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KBoolSort
 import org.usvm.UAddressSort
 import org.usvm.UBoolSort
-import org.usvm.UConcreteHeapRef
 import org.usvm.UHeapRef
 import org.usvm.collection.set.UAllocatedSetUpdatesTranslator
 import org.usvm.collection.set.UInputSetUpdatesTranslator
@@ -13,6 +11,7 @@ import org.usvm.collection.set.USetCollectionDecoder
 import org.usvm.collection.set.USymbolicSetElement
 import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
+import org.usvm.model.UModelEvaluator
 import org.usvm.solver.UExprTranslator
 import org.usvm.solver.URegionDecoder
 import org.usvm.solver.URegionTranslator
@@ -55,11 +54,10 @@ class URefSetRegionDecoder<SetType>(
     }
 
     override fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>
     ): UReadOnlyMemoryRegion<URefSetEntryLValue<SetType>, UBoolSort>? =
-        inputWithInputRegionTranslator?.let { URefSetLazyModelRegion(regionId, model, mapping, assertions, it) }
+        inputWithInputRegionTranslator?.let { URefSetLazyModelRegion(regionId, model, assertions, it) }
 }
 
 private class UAllocatedRefSetWithInputElementsTranslator<SetType>(

--- a/usvm-core/src/main/kotlin/org/usvm/constraints/TypeConstraints.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/constraints/TypeConstraints.kt
@@ -336,7 +336,7 @@ class UTypeConstraints<Type>(
         }
     }
 
-    private fun updateRegionCannotBeEqualNull(
+    private inline fun updateRegionCannotBeEqualNull(
         ref: USymbolicHeapRef,
         regionMapper: (UTypeRegion<Type>) -> UTypeRegion<Type>,
     ) {
@@ -360,7 +360,7 @@ class UTypeConstraints<Type>(
         setTypeRegion(ref, newRegion)
     }
 
-    private fun updateRegionCanBeEqualNull(
+    private inline fun updateRegionCanBeEqualNull(
         ref: USymbolicHeapRef,
         regionMapper: (UTypeRegion<Type>) -> UTypeRegion<Type>,
     ) {

--- a/usvm-core/src/main/kotlin/org/usvm/constraints/ULogicalConstraints.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/constraints/ULogicalConstraints.kt
@@ -1,6 +1,7 @@
 package org.usvm.constraints
 
 import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.persistentHashSetOf
 import kotlinx.collections.immutable.persistentSetOf
 import org.usvm.UBoolExpr
 import org.usvm.UContext
@@ -32,7 +33,7 @@ class ULogicalConstraints private constructor(
         get() = constraints.any(UBoolExpr::isFalse)
 
     fun contradiction(ctx: UContext<*>) {
-        constraints = persistentSetOf(ctx.falseExpr)
+        constraints = persistentHashSetOf(ctx.falseExpr)
     }
 
     /**
@@ -50,6 +51,6 @@ class ULogicalConstraints private constructor(
     }
 
     companion object {
-        fun empty() = ULogicalConstraints(persistentSetOf())
+        fun empty() = ULogicalConstraints(persistentHashSetOf())
     }
 }

--- a/usvm-core/src/main/kotlin/org/usvm/model/LazyModels.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/model/LazyModels.kt
@@ -1,6 +1,5 @@
 package org.usvm.model
 
-import io.ksmt.solver.KModel
 import io.ksmt.utils.asExpr
 import org.usvm.UExpr
 import org.usvm.UIndexedMethodReturnValue
@@ -20,19 +19,16 @@ import org.usvm.uctx
  * Provides translated symbolic constants for registers readings.
  */
 class ULazyRegistersStackModel(
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val translator: UExprTranslator<*, *>,
 ) : UReadOnlyRegistersStack {
-    private val uctx = translator.ctx
-
     override fun <Sort : USort> readRegister(
         index: Int,
         sort: Sort,
     ): UExpr<Sort> {
-        val registerReading = uctx.mkRegisterReading(index, sort)
+        val registerReading = translator.ctx.mkRegisterReading(index, sort)
         val translated = translator.translate(registerReading)
-        return model.eval(translated, isComplete = true).mapAddress(addressesMapping)
+        return model.evalAndComplete(translated)
     }
 }
 
@@ -44,14 +40,13 @@ class ULazyRegistersStackModel(
  * Provides translated symbolic constants for mock symbols.
  */
 class ULazyIndexedMockModel(
-    private val model: KModel,
-    private val addressesMapping: AddressesMapping,
+    private val model: UModelEvaluator<*>,
     private val translator: UExprTranslator<*, *>,
 ) : UMockEvaluator {
     override fun <Sort : USort> eval(symbol: UMockSymbol<Sort>): UExpr<Sort> {
         require(symbol is UIndexedMethodReturnValue<*, Sort>)
         val translated = translator.translate(symbol)
-        return model.eval(translated, isComplete = true).mapAddress(addressesMapping)
+        return model.evalAndComplete(translated)
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/model/Model.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/model/Model.kt
@@ -18,7 +18,6 @@ import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.UReadOnlyRegistersStack
 import org.usvm.memory.URegisterStackId
 import org.usvm.memory.UWritableMemory
-import org.usvm.sampleUValue
 
 interface UModel {
     fun <Sort : USort> eval(expr: UExpr<Sort>): UExpr<Sort>
@@ -55,8 +54,9 @@ open class UModelBase<Type>(
         if (regionId is URegisterStackId) {
             return stack.uncheckedCast()
         }
+
         return regions[regionId]?.uncheckedCast()
-            ?: DefaultRegion(regionId, eval(regionId.sort.sampleUValue()))
+            ?: error("Model has no region: $regionId")
     }
 
     override fun nullRef(): UHeapRef = nullRef
@@ -80,13 +80,6 @@ open class UModelBase<Type>(
 
     override fun allocStatic(type: Type): UConcreteHeapRef {
         error("Illegal operation for a model")
-    }
-
-    private class DefaultRegion<Key, Sort : USort>(
-        private val regionId: UMemoryRegionId<Key, Sort>,
-        private val value: UExpr<Sort>
-    ) : UReadOnlyMemoryRegion<Key, Sort> {
-        override fun read(key: Key): UExpr<Sort> = value
     }
 }
 

--- a/usvm-core/src/main/kotlin/org/usvm/model/ModelRegions.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/model/ModelRegions.kt
@@ -1,18 +1,9 @@
 package org.usvm.model
 
-import io.ksmt.expr.KArray2Store
-import io.ksmt.expr.KArrayConst
-import io.ksmt.expr.KArrayStore
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
-import io.ksmt.sort.KArray2Sort
-import io.ksmt.sort.KArraySort
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.collections.immutable.toPersistentMap
-import org.usvm.UConcreteHeapRef
+import kotlinx.collections.immutable.persistentHashMapOf
 import org.usvm.UExpr
-import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.UMemoryRegion
 import org.usvm.memory.UReadOnlyMemoryRegion
@@ -32,49 +23,9 @@ class UMemory1DArray<KeySort : USort, Sort : USort> internal constructor(
      */
     constructor(
         mappedConstValue: UExpr<Sort>,
-    ) : this(persistentMapOf(), mappedConstValue)
+    ) : this(persistentHashMapOf(), mappedConstValue)
 
     override fun read(key: KExpr<KeySort>): UExpr<Sort> = values.getOrDefault(key, constValue)
-
-    companion object {
-        /**
-         * A constructor that is used in regular cases for a region
-         * that has a corresponding translator. It collects information
-         * required for the region decoding using data about translated expressions,
-         * resolved values from the [model] and the [mapping] from address expressions
-         * to their concrete representation.
-         */
-        operator fun <KeySort : USort, Sort : USort> invoke(
-            initialValue: KExpr<KArraySort<KeySort, Sort>>,
-            model: KModel,
-            mapping: Map<UHeapRef, UConcreteHeapRef>,
-        ): UMemory1DArray<KeySort, Sort> {
-            // Since the model contains only information about values we got from the outside,
-            // we can translate and ask only about an initial value for the region.
-            // All other values should be resolved earlier without asking the model.
-            val evaluatedArray = model.eval(initialValue, isComplete = true)
-
-            var valueCopy = evaluatedArray
-
-            val stores = mutableMapOf<UExpr<KeySort>, UExpr<Sort>>()
-
-            // Parse stores into the region, then collect a const value for the evaluated region.
-            while (valueCopy !is KArrayConst<*, *>) {
-                require(valueCopy is KArrayStore<KeySort, Sort>)
-
-                val value = valueCopy.value.mapAddress(mapping)
-
-                val mapAddress = valueCopy.index.mapAddress(mapping)
-                stores[mapAddress] = value
-                valueCopy = valueCopy.array
-            }
-            @Suppress("UNCHECKED_CAST")
-            valueCopy as KArrayConst<KArraySort<KeySort, Sort>, Sort>
-
-            val constValue = valueCopy.value.mapAddress(mapping)
-            return UMemory1DArray(stores.toPersistentMap(), constValue)
-        }
-    }
 }
 
 /**
@@ -91,48 +42,9 @@ class UMemory2DArray<Key1Sort : USort, Key2Sort : USort, Sort : USort> internal 
      */
     constructor(
         mappedConstValue: UExpr<Sort>,
-    ) : this(persistentMapOf(), mappedConstValue)
+    ) : this(persistentHashMapOf(), mappedConstValue)
 
     override fun read(key: Pair<KExpr<Key1Sort>, KExpr<Key2Sort>>): UExpr<Sort> {
         return values.getOrDefault(key, constValue)
-    }
-
-    companion object {
-        /**
-         * A constructor that is used in regular cases for a region
-         * that has a corresponding translator. It collects information
-         * required for the region decoding using data about translated expressions,
-         * resolved values from the [model] and the [mapping] from address expressions
-         * to their concrete representation.
-         */
-        operator fun <Key1Sort : USort, Key2Sort : USort, Sort : USort> invoke(
-            initialValue: KExpr<KArray2Sort<Key1Sort, Key2Sort, Sort>>,
-            model: KModel,
-            mapping: Map<UHeapRef, UConcreteHeapRef>,
-        ): UMemory2DArray<Key1Sort, Key2Sort, Sort> {
-            val evaluatedArray = model.eval(initialValue, isComplete = true)
-
-            var valueCopy = evaluatedArray
-
-            val stores = mutableMapOf<Pair<UExpr<Key1Sort>, UExpr<Key2Sort>>, UExpr<Sort>>()
-
-            while (valueCopy !is KArrayConst<*, *>) {
-                require(valueCopy is KArray2Store<Key1Sort, Key2Sort, Sort>)
-
-                val value = valueCopy.value.mapAddress(mapping)
-
-                val index0 = valueCopy.index0.mapAddress(mapping)
-                val index1 = valueCopy.index1.mapAddress(mapping)
-
-                stores[index0 to index1] = value
-                valueCopy = valueCopy.array
-            }
-
-            @Suppress("UNCHECKED_CAST")
-            valueCopy as KArrayConst<KArray2Sort<Key1Sort, Key2Sort, Sort>, Sort>
-
-            val constValue = valueCopy.value.mapAddress(mapping)
-            return UMemory2DArray(stores.toPersistentMap(), constValue)
-        }
     }
 }

--- a/usvm-core/src/main/kotlin/org/usvm/model/UModelEvaluator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/model/UModelEvaluator.kt
@@ -1,0 +1,221 @@
+package org.usvm.model
+
+import io.ksmt.decl.KDecl
+import io.ksmt.expr.KArray2Store
+import io.ksmt.expr.KArrayConst
+import io.ksmt.expr.KArrayStore
+import io.ksmt.expr.KExpr
+import io.ksmt.expr.KFunctionAsArray
+import io.ksmt.expr.KInterpretedValue
+import io.ksmt.solver.KModel
+import io.ksmt.solver.model.KFuncInterp
+import io.ksmt.solver.model.KFuncInterpEntryOneAry
+import io.ksmt.solver.model.KFuncInterpEntryTwoAry
+import io.ksmt.solver.model.KFuncInterpVarsFree
+import io.ksmt.sort.KArray2Sort
+import io.ksmt.sort.KArray3Sort
+import io.ksmt.sort.KArrayNSort
+import io.ksmt.sort.KArraySort
+import io.ksmt.sort.KArraySortBase
+import io.ksmt.sort.KBoolSort
+import io.ksmt.sort.KBvSort
+import io.ksmt.sort.KFpRoundingModeSort
+import io.ksmt.sort.KFpSort
+import io.ksmt.sort.KIntSort
+import io.ksmt.sort.KRealSort
+import io.ksmt.sort.KSort
+import io.ksmt.sort.KSortVisitor
+import io.ksmt.sort.KUninterpretedSort
+import io.ksmt.utils.uncheckedCast
+import kotlinx.collections.immutable.persistentHashMapOf
+import org.usvm.NULL_ADDRESS
+import org.usvm.UContext
+import org.usvm.UExpr
+import org.usvm.UHeapRef
+import org.usvm.USort
+import org.usvm.mkSizeExpr
+import org.usvm.sizeSort
+
+/**
+ * Retrieves an expression interpretation from the provided [model].
+ * In the case when the expression is free in the [model] completes model wrt expression sort.
+ * */
+open class UModelEvaluator<SizeSort : USort>(
+    val ctx: UContext<SizeSort>,
+    val model: KModel,
+    val addressesMapping: AddressesMapping,
+) : KSortVisitor<UExpr<*>> {
+    val completedValues = hashMapOf<KExpr<*>, UExpr<*>>()
+    val completed1DArrays = hashMapOf<KDecl<*>, UMemory1DArray<*, *>>()
+    val completed2DArrays = hashMapOf<KDecl<*>, UMemory2DArray<*, *, *>>()
+
+    open fun visitSize(): UExpr<SizeSort> = ctx.mkSizeExpr(0)
+    open fun visitAddress(): UHeapRef = ctx.mkConcreteHeapRef(NULL_ADDRESS)
+
+    override fun visit(sort: KBoolSort): UExpr<*> = ctx.defaultValueSampler.visit(sort)
+
+    override fun <S : KBvSort> visit(sort: S): UExpr<*> = if (sort == ctx.sizeSort) {
+        visitSize()
+    } else {
+        ctx.defaultValueSampler.visit(sort)
+    }
+
+    override fun visit(sort: KIntSort): UExpr<*> = if (sort == ctx.sizeSort) {
+        visitSize()
+    } else {
+        ctx.defaultValueSampler.visit(sort)
+    }
+
+    override fun visit(sort: KUninterpretedSort): UExpr<*> = if (sort == ctx.addressSort) {
+        visitAddress()
+    } else {
+        ctx.defaultValueSampler.visit(sort)
+    }
+
+    override fun visit(sort: KRealSort): UExpr<*> = ctx.defaultValueSampler.visit(sort)
+    override fun visit(sort: KFpRoundingModeSort): UExpr<*> = ctx.defaultValueSampler.visit(sort)
+    override fun <S : KFpSort> visit(sort: S): UExpr<*> = ctx.defaultValueSampler.visit(sort)
+
+    override fun <D : KSort, R : KSort> visit(sort: KArraySort<D, R>): UExpr<*> =
+        ctx.mkArrayConst(sort, sort.range.accept(this).uncheckedCast())
+
+    override fun <D0 : KSort, D1 : KSort, R : KSort> visit(sort: KArray2Sort<D0, D1, R>): UExpr<*> =
+        ctx.mkArrayConst(sort, sort.range.accept(this).uncheckedCast())
+
+    override fun <D0 : KSort, D1 : KSort, D2 : KSort, R : KSort> visit(sort: KArray3Sort<D0, D1, D2, R>): UExpr<*> =
+        ctx.mkArrayConst(sort, sort.range.accept(this).uncheckedCast())
+
+    override fun <R : KSort> visit(sort: KArrayNSort<R>): UExpr<*> =
+        ctx.mkArrayConst(sort, sort.range.accept(this).uncheckedCast())
+
+    /**
+     * Evaluate simple (not an array) expression in the model.
+     * Complete model according to the expression sort if expr is free in the model.
+     * */
+    open fun <Sort : USort> evalAndComplete(expr: UExpr<Sort>): UExpr<Sort> {
+        val modelValue = model.eval(expr, isComplete = false)
+        if (modelValue is KInterpretedValue<*>) {
+            return modelValue.mapAddress(addressesMapping).uncheckedCast()
+        }
+
+        return completedValues.getOrPut(expr) {
+            check(expr.sort !is KArraySortBase<*>) { "Unexpected array expression $expr" }
+
+            expr.sort.accept(this)
+        }.uncheckedCast()
+    }
+
+    /**
+     * Evaluate 1D array expression in the model.
+     * Complete model according to the array range (value) sort if array is free in the model.
+     * */
+    open fun <Idx : USort, Value : USort> evalAndCompleteArray1DMemoryRegion(
+        translated: KDecl<KArraySort<Idx, Value>>,
+    ): UMemory1DArray<Idx, Value> {
+        val interpretation = model.interpretation(translated)
+
+        val stores = persistentHashMapOf<UExpr<Idx>, UExpr<Value>>().builder()
+        val defaultValue = interpretation?.let {
+            traverse1DArrayEntries(interpretation) { idx, value ->
+                stores[idx.mapAddress(addressesMapping)] = value.mapAddress(addressesMapping)
+            }
+        }
+
+        if (defaultValue != null) {
+            return UMemory1DArray(stores.build(), defaultValue.mapAddress(addressesMapping))
+        }
+
+        return completed1DArrays.getOrPut(translated) {
+            val completedDefault = translated.sort.range.accept(this)
+            UMemory1DArray(stores.build(), completedDefault.uncheckedCast())
+        }.uncheckedCast()
+    }
+
+    /**
+     * Evaluate 2D array expression in the model.
+     * Complete model according to the array range (value) sort if array is free in the model.
+     * */
+    open fun <Idx1 : USort, Idx2 : USort, Value : USort> evalAndCompleteArray2DMemoryRegion(
+        translated: KDecl<KArray2Sort<Idx1, Idx2, Value>>,
+    ): UMemory2DArray<Idx1, Idx2, Value> {
+        val interpretation = model.interpretation(translated)
+
+        val stores = persistentHashMapOf<Pair<UExpr<Idx1>, UExpr<Idx2>>, UExpr<Value>>().builder()
+        val defaultValue = interpretation?.let {
+            traverse2DArrayEntries(interpretation) { idx1, idx2, value ->
+                val mappedIdx1 = idx1.mapAddress(addressesMapping)
+                val mappedIdx2 = idx2.mapAddress(addressesMapping)
+                stores[mappedIdx1 to mappedIdx2] = value.mapAddress(addressesMapping)
+            }
+        }
+
+        if (defaultValue != null) {
+            return UMemory2DArray(stores.build(), defaultValue.mapAddress(addressesMapping))
+        }
+
+        return completed2DArrays.getOrPut(translated) {
+            val completedDefault = translated.sort.range.accept(this)
+            UMemory2DArray(stores.build(), completedDefault.uncheckedCast())
+        }.uncheckedCast()
+    }
+
+    /**
+     * In the KSMT there are two representations for the array model:
+     * 1. A bunch of an array store expressions with the constant array base.
+     * Usually returned by the Z3 solver.
+     * 2. (function-as-array) and the function interpretation.
+     * Usually returned by the Yices solver.
+     *
+     * In the latter case we can avoid intermediate conversion to the array-store style representation.
+     * */
+    inline fun <Idx : USort, Value : USort> traverse1DArrayEntries(
+        interpretation: KFuncInterp<KArraySort<Idx, Value>>,
+        onEntry: (KExpr<Idx>, KExpr<Value>) -> Unit
+    ): KExpr<Value>? {
+        var arrayInterpretation = interpretation.default ?: return null
+        if (arrayInterpretation is KFunctionAsArray<*, *>) {
+            val functionInterpretation = model.interpretation(arrayInterpretation.function) ?: return null
+            check(functionInterpretation is KFuncInterpVarsFree<*>) { "Unexpected vars in array interpretation" }
+            for (entry in functionInterpretation.entries) {
+                entry as KFuncInterpEntryOneAry<*>
+                onEntry(entry.arg.uncheckedCast(), entry.value.uncheckedCast())
+            }
+            return functionInterpretation.default?.uncheckedCast()
+        }
+
+        while (arrayInterpretation is KArrayStore<Idx, Value>) {
+            onEntry(arrayInterpretation.index, arrayInterpretation.value)
+            arrayInterpretation = arrayInterpretation.array
+        }
+
+        check(arrayInterpretation is KArrayConst<*, *>) { "Unexpected array: $arrayInterpretation" }
+        return arrayInterpretation.value.uncheckedCast()
+    }
+
+    /**
+     * See [traverse1DArrayEntries] for the details.
+     * */
+    inline fun <Idx1 : USort, Idx2 : USort, Value : USort> traverse2DArrayEntries(
+        interpretation: KFuncInterp<KArray2Sort<Idx1, Idx2, Value>>,
+        onEntry: (KExpr<Idx1>, KExpr<Idx2>, KExpr<Value>) -> Unit
+    ): KExpr<Value>? {
+        var arrayInterpretation = interpretation.default ?: return null
+        if (arrayInterpretation is KFunctionAsArray<*, *>) {
+            val functionInterpretation = model.interpretation(arrayInterpretation.function) ?: return null
+            check(functionInterpretation is KFuncInterpVarsFree<*>) { "Unexpected vars in array interpretation" }
+            for (entry in functionInterpretation.entries) {
+                entry as KFuncInterpEntryTwoAry<*>
+                onEntry(entry.arg0.uncheckedCast(), entry.arg1.uncheckedCast(), entry.value.uncheckedCast())
+            }
+            return functionInterpretation.default?.uncheckedCast()
+        }
+
+        while (arrayInterpretation is KArray2Store<Idx1, Idx2, Value>) {
+            onEntry(arrayInterpretation.index0, arrayInterpretation.index1, arrayInterpretation.value)
+            arrayInterpretation = arrayInterpretation.array
+        }
+
+        check(arrayInterpretation is KArrayConst<*, *>) { "Unexpected array: $arrayInterpretation" }
+        return arrayInterpretation.value.uncheckedCast()
+    }
+}

--- a/usvm-core/src/main/kotlin/org/usvm/solver/RegionTranslator.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/solver/RegionTranslator.kt
@@ -2,13 +2,10 @@ package org.usvm.solver
 
 import io.ksmt.KContext
 import io.ksmt.expr.KExpr
-import io.ksmt.solver.KModel
 import io.ksmt.sort.KArray2Sort
 import io.ksmt.sort.KArraySort
 import io.ksmt.sort.KBoolSort
-import org.usvm.UConcreteHeapRef
 import org.usvm.UExpr
-import org.usvm.UHeapRef
 import org.usvm.USort
 import org.usvm.memory.UMemoryUpdatesVisitor
 import org.usvm.memory.UPinpointUpdateNode
@@ -17,6 +14,7 @@ import org.usvm.memory.UReadOnlyMemoryRegion
 import org.usvm.memory.USymbolicCollection
 import org.usvm.memory.USymbolicCollectionId
 import org.usvm.memory.UUpdateNode
+import org.usvm.model.UModelEvaluator
 import org.usvm.uctx
 
 /**
@@ -29,14 +27,13 @@ interface URegionTranslator<CollectionId : USymbolicCollectionId<Key, Sort, Coll
 
 interface URegionDecoder<Key, Sort : USort> {
     fun decodeLazyRegion(
-        model: KModel,
-        mapping: Map<UHeapRef, UConcreteHeapRef>,
+        model: UModelEvaluator<*>,
         assertions: List<KExpr<KBoolSort>>,
     ): UReadOnlyMemoryRegion<Key, Sort>?
 }
 
 interface UCollectionDecoder<Key, Sort : USort> {
-    fun decodeCollection(model: KModel, mapping: Map<UHeapRef, UConcreteHeapRef>): UReadOnlyMemoryRegion<Key, Sort>
+    fun decodeCollection(model: UModelEvaluator<*>): UReadOnlyMemoryRegion<Key, Sort>
 }
 
 /**

--- a/usvm-core/src/main/kotlin/org/usvm/types/TypeRegion.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/types/TypeRegion.kt
@@ -1,7 +1,7 @@
 package org.usvm.types
 
 import kotlinx.collections.immutable.PersistentSet
-import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.persistentHashSetOf
 import org.usvm.regions.Region
 
 /**
@@ -10,10 +10,10 @@ import org.usvm.regions.Region
 class UTypeRegion<Type>(
     val typeSystem: UTypeSystem<Type>,
     val typeStream: UTypeStream<Type>,
-    val supertypes: PersistentSet<Type> = persistentSetOf(),
-    val notSupertypes: PersistentSet<Type> = persistentSetOf(),
-    val subtypes: PersistentSet<Type> = persistentSetOf(),
-    val notSubtypes: PersistentSet<Type> = persistentSetOf(),
+    val supertypes: PersistentSet<Type> = persistentHashSetOf(),
+    val notSupertypes: PersistentSet<Type> = persistentHashSetOf(),
+    val subtypes: PersistentSet<Type> = persistentHashSetOf(),
+    val notSubtypes: PersistentSet<Type> = persistentHashSetOf(),
 ) : Region<UTypeRegion<Type>> {
     /**
      * Returns region that represents empty set of types. Called when type
@@ -248,8 +248,8 @@ class UTypeRegion<Type>(
 
         return clone(
             USingleTypeStream(typeSystem, type),
-            supertypes = persistentSetOf(type),
-            subtypes = persistentSetOf(type)
+            supertypes = persistentHashSetOf(type),
+            subtypes = persistentHashSetOf(type)
         )
     }
 
@@ -269,8 +269,8 @@ class UTypeRegion<Type>(
         fun <Type> fromSingleType(typeSystem: UTypeSystem<Type>, type: Type): UTypeRegion<Type> = UTypeRegion(
             typeSystem,
             USingleTypeStream(typeSystem, type),
-            supertypes = persistentSetOf(type),
-            subtypes = persistentSetOf(type)
+            supertypes = persistentHashSetOf(type),
+            subtypes = persistentHashSetOf(type)
         )
     }
 }

--- a/usvm-jvm/src/test/kotlin/org/usvm/samples/exceptions/ExceptionExamplesTest.kt
+++ b/usvm-jvm/src/test/kotlin/org/usvm/samples/exceptions/ExceptionExamplesTest.kt
@@ -135,7 +135,8 @@ internal class ExceptionExamplesTest : JavaMethodTestRunner() {
             ExceptionExamples::tryThrowableMethod,
             eq(2),
             { _, r -> r == NullPointerException::class.java },
-            { _, r -> r == Throwable::class.java },
+            // Since we mock all methods of java.lang.Throwable getCause can return ANY Throwable
+            { _, r -> r != null && Throwable::class.java.isAssignableFrom(r) },
         )
     }
 }

--- a/usvm-util/src/main/kotlin/org/usvm/algorithms/DeterministicPriorityCollection.kt
+++ b/usvm-util/src/main/kotlin/org/usvm/algorithms/DeterministicPriorityCollection.kt
@@ -1,5 +1,6 @@
 package org.usvm.algorithms
 
+import org.usvm.util.assert
 import java.util.PriorityQueue
 import kotlin.Comparator
 import kotlin.NoSuchElementException
@@ -8,28 +9,46 @@ import kotlin.NoSuchElementException
  * [UPriorityCollection] implementation based on [java.util.PriorityQueue].
  */
 // TODO: what to do if elements have same priority?
-class DeterministicPriorityCollection<T, Priority>(comparator: Comparator<Priority>) :
+class DeterministicPriorityCollection<T, Priority>(private val comparator: Comparator<Priority>) :
     UPriorityCollection<T, Priority> {
-
+    private var topElement: Pair<T, Priority>? = null
     private val priorityQueue = PriorityQueue<Pair<T, Priority>> { (_, p1), (_, p2) -> comparator.compare(p1, p2) }
 
-    override val count: Int get() = priorityQueue.size
+    override val count: Int get() = priorityQueue.size + if (topElement == null) 0 else 1
 
-    override fun peek(): T = priorityQueue.element().first
+    override fun peek(): T {
+        if (topElement == null) {
+            topElement = priorityQueue.remove()
+        }
+        return topElement!!.first
+    }
 
     override fun update(element: T, priority: Priority) {
         remove(element)
-        priorityQueue.add(element to priority)
+        add(element, priority)
     }
 
     override fun remove(element: T) {
+        // Don't traverse the whole queue if we remove the top element
+        if (topElement != null && topElement?.first == element) {
+            topElement = null
+            return
+        }
+
         if (!priorityQueue.removeIf { (e, _) -> e == element }) {
             throw NoSuchElementException("Element not found in priority queue")
         }
     }
 
     override fun add(element: T, priority: Priority) {
-        check(!priorityQueue.any { (e, _) -> e == element }) { "Element already exists in priority queue" }
+        assert({ !priorityQueue.any { (e, _) -> e == element } }) { "Element already exists in priority queue" }
+
+        val currentTop = topElement
+        if (currentTop != null && comparator.compare(currentTop.second, priority) < 0) {
+            topElement = element to priority
+            priorityQueue.add(currentTop)
+            return
+        }
         priorityQueue.add(element to priority)
     }
 }

--- a/usvm-util/src/main/kotlin/org/usvm/algorithms/PersistentMultiMapBuilder.kt
+++ b/usvm-util/src/main/kotlin/org/usvm/algorithms/PersistentMultiMapBuilder.kt
@@ -1,0 +1,95 @@
+package org.usvm.algorithms
+
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.persistentHashSetOf
+import kotlinx.collections.immutable.toPersistentHashSet
+
+typealias PersistentMultiMap<K, V> = PersistentMap<K, PersistentSet<V>>
+
+/**
+ * Provides an efficient way to perform multiple mutations on [PersistentMultiMap].
+ * */
+class PersistentMultiMapBuilder<K, V>(original: PersistentMultiMap<K, V>) : Iterable<Pair<K, V>> {
+    private val map = original.builder()
+
+    fun build(): PersistentMultiMap<K, V> = map.build()
+
+    fun containsValue(key: K, value: V): Boolean =
+        map[key]?.contains(value) ?: false
+
+    fun isEmpty(): Boolean = map.isEmpty()
+
+    operator fun get(key: K): Set<V>? = map[key]
+
+    fun add(key: K, value: V) {
+        val current = map[key]
+        val updated = current?.add(value) ?: persistentHashSetOf(value)
+        map[key] = updated
+    }
+
+    fun addAll(key: K, values: Set<V>) {
+        val current = map[key]
+        val updated = current?.addAll(values) ?: values.toPersistentHashSet()
+        map[key] = updated
+    }
+
+    fun remove(key: K): Set<V>? = map.remove(key)
+
+    fun removeValue(key: K, value: V) {
+        val current = map[key] ?: return
+        val updated = current.remove(value)
+        map[key] = updated
+    }
+
+    fun removeAllValues(key: K, values: Set<V>) {
+        val current = map[key] ?: return
+        val updated = current.removeAll(values)
+        map[key] = updated
+    }
+
+    fun clear() {
+        map.clear()
+    }
+
+    override fun iterator(): Iterator<Pair<K, V>> = MultiMapIterator(map)
+
+    override fun equals(other: Any?): Boolean = when {
+        this === other -> true
+        other is PersistentMultiMapBuilder<*, *> -> map == other.map
+        other is Map<*, *> -> map == other
+        else -> false
+    }
+
+    override fun hashCode(): Int = map.hashCode()
+
+    private class MultiMapIterator<K, V>(
+        mapBuilder: MutableMap<K, PersistentSet<V>>
+    ) : Iterator<Pair<K, V>> {
+        private val valueIterators = mapBuilder.entries.mapTo(mutableListOf()) { it.key to it.value.iterator() }
+        private var value: Pair<K, V>? = null
+
+        override fun hasNext(): Boolean {
+            propagate()
+            return value != null
+        }
+
+        override fun next(): Pair<K, V> {
+            propagate()
+            val result = value ?: throw NoSuchElementException("Iterator is empty")
+            value = null
+            return result
+        }
+
+        private fun propagate() {
+            while (value === null) {
+                val lastIterator = valueIterators.lastOrNull() ?: return
+                if (!lastIterator.second.hasNext()) {
+                    valueIterators.removeLast()
+                    continue
+                }
+                value = lastIterator.first to lastIterator.second.next()
+            }
+        }
+    }
+}

--- a/usvm-util/src/main/kotlin/org/usvm/regions/RegionTree.kt
+++ b/usvm-util/src/main/kotlin/org/usvm/regions/RegionTree.kt
@@ -292,4 +292,7 @@ private typealias CompletelyCoveredRegionTree<Reg, Value> = RegionTree<Reg, Valu
 private typealias RegionTreeMapEntry<Reg, Value> = Map.Entry<Reg, Pair<Value, RegionTree<Reg, Value>>>
 private typealias RegionTreeEntryIterator<Reg, Value> = Iterator<RegionTreeMapEntry<Value, Reg>>
 
-fun <Reg : Region<Reg>, Value> emptyRegionTree() = RegionTree<Reg, Value>(persistentMapOf())
+private val EMPTY_REGION = RegionTree<Nothing, Nothing>(persistentMapOf())
+
+@Suppress("UNCHECKED_CAST")
+fun <Reg : Region<Reg>, Value> emptyRegionTree(): RegionTree<Reg, Value> = EMPTY_REGION as RegionTree<Reg, Value>

--- a/usvm-util/src/main/kotlin/org/usvm/util/Assertions.kt
+++ b/usvm-util/src/main/kotlin/org/usvm/util/Assertions.kt
@@ -1,0 +1,17 @@
+package org.usvm.util
+
+@PublishedApi
+internal object Assertions {
+    @JvmField
+    @PublishedApi
+    internal val ENABLED: Boolean = javaClass.desiredAssertionStatus()
+}
+
+/**
+ * Assert that evaluates [condition] only if assertions are enabled (e.g. during tests)
+ * */
+inline fun assert(condition: () -> Boolean, message: () -> String) {
+    if (Assertions.ENABLED) {
+        assert(condition()) { message() }
+    }
+}


### PR DESCRIPTION
1. Use non-linked persistent hash maps. 
2. Use persistent hash map builders to improve bulk mutations.
3. Introduce `UModelEvaluator` to allow model completion strategy customization. Such strategies can significantly improve performance in some usage scenarios. For example, we can complete addresses with concrete refs instead of null.
4. Few minor fixes.