### PR TITLE
JcMachineOptions and implicit exceptions

### DIFF
--- a/usvm-jvm/src/main/kotlin/org/usvm/api/checkers/JcChecker.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/api/checkers/JcChecker.kt
@@ -43,7 +43,7 @@ class JcCheckerRunner(val cp: JcClasspath) {
     ) {
         val checkersObserver = JcCheckerObserver(checkersVisitor, apiImpl)
 
-        JcMachine(cp, options, checkersObserver).use { machine ->
+        JcMachine(cp, options, interpreterObserver = checkersObserver).use { machine ->
             machine.analyze(entryPoint, targets)
         }
     }

--- a/usvm-jvm/src/main/kotlin/org/usvm/machine/JcMachine.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/machine/JcMachine.kt
@@ -43,6 +43,7 @@ val logger = object : KLogging() {}.logger
 class JcMachine(
     cp: JcClasspath,
     private val options: UMachineOptions,
+    private val jcMachineOptions: JcMachineOptions = JcMachineOptions(),
     private val interpreterObserver: JcInterpreterObserver? = null,
 ) : UMachine<JcState>() {
     private val applicationGraph = JcApplicationGraph(cp)
@@ -51,7 +52,7 @@ class JcMachine(
     private val components = JcComponents(typeSystem, options)
     private val ctx = JcContext(cp, components)
 
-    private val interpreter = JcInterpreter(ctx, applicationGraph, interpreterObserver)
+    private val interpreter = JcInterpreter(ctx, applicationGraph, jcMachineOptions, interpreterObserver)
 
     private val cfgStatistics = CfgStatisticsImpl(applicationGraph)
 

--- a/usvm-jvm/src/main/kotlin/org/usvm/machine/JcMachineOptions.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/machine/JcMachineOptions.kt
@@ -1,0 +1,22 @@
+package org.usvm.machine
+
+/**
+ * JcMachine specific options.
+ * */
+data class JcMachineOptions(
+    /**
+     * During virtual call resolution the machine should consider all possible call implementations.
+     * By default, the machine forks on few concrete implementation and ignore remaining.
+     * */
+    val forkOnRemainingTypes: Boolean = false,
+
+    /**
+     * Controls, whether the machine should analyze states with implicit exceptions (e.g. NPE).
+     * */
+    val forkOnImplicitExceptions: Boolean = true,
+
+    /**
+     * Hard constraint for maximal array size.
+     * */
+    val arrayMaxSize: Int = 1_500,
+)

--- a/usvm-jvm/src/main/kotlin/org/usvm/machine/interpreter/JcInterpreter.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/machine/interpreter/JcInterpreter.kt
@@ -53,6 +53,7 @@ import org.usvm.machine.JcConcreteMethodCallInst
 import org.usvm.machine.JcContext
 import org.usvm.machine.JcDynamicMethodCallInst
 import org.usvm.machine.JcInterpreterObserver
+import org.usvm.machine.JcMachineOptions
 import org.usvm.machine.JcMethodApproximationResolver
 import org.usvm.machine.JcMethodCall
 import org.usvm.machine.JcMethodCallBaseInst
@@ -78,6 +79,7 @@ import org.usvm.types.singleOrNull
 import org.usvm.util.name
 import org.usvm.util.outerClassInstanceField
 import org.usvm.util.write
+import org.usvm.utils.logAssertFailure
 import org.usvm.utils.onStateDeath
 
 typealias JcStepScope = StepScope<JcState, JcType, JcInst, JcContext>
@@ -88,6 +90,7 @@ typealias JcStepScope = StepScope<JcState, JcType, JcInst, JcContext>
 class JcInterpreter(
     private val ctx: JcContext,
     private val applicationGraph: JcApplicationGraph,
+    private val options: JcMachineOptions,
     private val observer: JcInterpreterObserver? = null,
     var forkBlackList: UForkBlackList<JcState, JcInst> = UForkBlackList.createDefault(),
 ) : UInterpreter<JcState>() {
@@ -303,7 +306,7 @@ class JcInterpreter(
                     return
                 }
 
-                resolveVirtualInvoke(stmt, scope, forkOnRemainingTypes = false)
+                resolveVirtualInvoke(stmt, scope)
             }
 
             is JcDynamicMethodCallInst -> {
@@ -399,32 +402,29 @@ class JcInterpreter(
         val lvalue = exprResolver.resolveLValue(stmt.lhv) ?: return
         val expr = exprResolver.resolveJcExpr(stmt.rhv, stmt.lhv.type) ?: return
 
-        val noArrayStoreException = checkArrayStoreException(lvalue, expr, scope)
+        checkArrayStoreException(lvalue, expr, exprResolver, scope) ?: return
 
-        scope.fork(
-            noArrayStoreException,
-            blockOnTrueState = {
-                val nextStmt = stmt.nextStmt
-                memory.write(lvalue, expr)
-                newStmt(nextStmt)
-            },
-            blockOnFalseState = exprResolver.allocateException(ctx.arrayStoreExceptionType)
-        )
+        scope.doWithState {
+            val nextStmt = stmt.nextStmt
+            memory.write(lvalue, expr)
+            newStmt(nextStmt)
+        }
     }
 
     // Returns `trueExpr` if ArrayStoreException is impossible
     private fun checkArrayStoreException(
         lvalue: ULValue<*, *>,
         rvalue: UExpr<out USort>,
+        exprResolver: JcExprResolver,
         scope: JcStepScope
-    ): UBoolExpr {
+    ): Unit? {
         if (lvalue !is UArrayIndexLValue<*, *, *>) {
-            return ctx.trueExpr
+            return Unit
         }
 
         // ArrayStoreException is possible only for references
         if (rvalue.sort != ctx.addressSort) {
-            return ctx.trueExpr
+            return Unit
         }
 
         check(lvalue.sort == rvalue.sort) {
@@ -462,7 +462,15 @@ class JcInterpreter(
             ctx.mkAnd(elementTypeConstraints, arrayTypeConstraints)
         }
 
-        return isRvalueSubtypeOf
+        return if (options.forkOnImplicitExceptions) {
+            scope.fork(
+                isRvalueSubtypeOf,
+                blockOnFalseState = exprResolver.allocateException(ctx.arrayStoreExceptionType)
+            )
+        } else {
+            scope.assert(isRvalueSubtypeOf)
+                .logAssertFailure { "Jc implicit exception: Check ArrayStoreException" }
+        }
     }
 
     private fun visitIfStmt(scope: JcStepScope, stmt: JcIfInst) {
@@ -624,6 +632,7 @@ class JcInterpreter(
         JcExprResolver(
             ctx,
             scope,
+            options,
             ::mapLocalToIdxMapper,
             ::typeInstanceAllocator,
             ::stringConstantAllocator,
@@ -697,8 +706,7 @@ class JcInterpreter(
     private fun resolveVirtualInvoke(
         methodCall: JcVirtualMethodCallInst,
         scope: JcStepScope,
-        forkOnRemainingTypes: Boolean,
-    ): Unit = resolveVirtualInvoke(ctx, methodCall, scope, typeSelector, forkOnRemainingTypes)
+    ): Unit = resolveVirtualInvoke(ctx, methodCall, scope, typeSelector, options.forkOnRemainingTypes)
 
     private val approximationResolver = JcMethodApproximationResolver(ctx, applicationGraph)
 

--- a/usvm-jvm/src/test/kotlin/org/usvm/samples/JavaMethodTestRunner.kt
+++ b/usvm-jvm/src/test/kotlin/org/usvm/samples/JavaMethodTestRunner.kt
@@ -780,7 +780,7 @@ open class JavaMethodTestRunner : TestRunner<JcTest, KFunction<*>, KClass<*>?, J
     override val runner: (KFunction<*>, UMachineOptions) -> List<JcTest> = { method, options ->
         val jcMethod = cp.getJcMethodByName(method)
 
-        JcMachine(cp, options, interpreterObserver).use { machine ->
+        JcMachine(cp, options, interpreterObserver = interpreterObserver).use { machine ->
             val states = machine.analyze(jcMethod.method, targets)
             states.map { testResolver.resolve(jcMethod, it, machine.stringConstants) }
         }


### PR DESCRIPTION
* Introduce `JcMachineOptions`  instead of options throughout the code.
* Add new option to control implicit exceptions analysis. 