### PR TITLE
Fix parent static field instrumentation

### DIFF
--- a/usvm-jvm-instrumentation/src/samples/java/example/ClassWithStaticField.java
+++ b/usvm-jvm-instrumentation/src/samples/java/example/ClassWithStaticField.java
@@ -1,0 +1,5 @@
+package example;
+
+public class ClassWithStaticField {
+    public static String STATIC_FIELD = "static field content";
+}

--- a/usvm-jvm-instrumentation/src/samples/java/example/ParentStaticFieldUser.java
+++ b/usvm-jvm-instrumentation/src/samples/java/example/ParentStaticFieldUser.java
@@ -1,0 +1,7 @@
+package example;
+
+public class ParentStaticFieldUser extends ClassWithStaticField {
+    public static String getParentStaticField() {
+        return ParentStaticFieldUser.STATIC_FIELD;
+    }
+}

--- a/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
+++ b/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
@@ -9,6 +9,7 @@ import org.usvm.instrumentation.testcase.api.UTestExecutionExceptionResult
 import org.usvm.instrumentation.testcase.api.UTestExecutionSuccessResult
 import org.usvm.instrumentation.testcase.descriptor.UTestConstantDescriptor
 import org.usvm.instrumentation.util.UTestCreator
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -247,5 +248,17 @@ class ConcreteExecutorTests: UTestConcreteExecutorTest() {
         val res = uTestConcreteExecutor.executeAsync(uTest)
         assertIs<UTestExecutionSuccessResult>(res)
     }
+
+    @Test
+    fun `get parent static field`() = executeTest {
+        val uTest = UTestCreator.ParentStaticFieldUser.getParentStaticField(jcClasspath)
+        val res = uTestConcreteExecutor.executeAsync(uTest)
+        assertIs<UTestExecutionSuccessResult>(res)
+        val result = res.result
+        assertNotNull(result)
+        assertIs<UTestConstantDescriptor.String>(result)
+        assertEquals("static field content", result.value)
+        assertContains(res.resultState.statics.keys.map { it.name }, "STATIC_FIELD")
+    }.also { println(0) }
 
 }

--- a/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
+++ b/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
@@ -259,6 +259,6 @@ class ConcreteExecutorTests: UTestConcreteExecutorTest() {
         assertIs<UTestConstantDescriptor.String>(result)
         assertEquals("static field content", result.value)
         assertContains(res.resultState.statics.keys.map { it.name }, "STATIC_FIELD")
-    }.also { println(0) }
+    }
 
 }

--- a/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/util/UTestCreator.kt
+++ b/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/util/UTestCreator.kt
@@ -498,4 +498,13 @@ object UTestCreator {
             return UTest(listOf(), methodCall)
         }
     }
+
+    object ParentStaticFieldUser {
+        fun getParentStaticField(jcClasspath: JcClasspath): UTest {
+            val jcClass = jcClasspath.findClass("example.ParentStaticFieldUser")
+            val jcMethod = jcClass.declaredMethods.find { it.name == "getParentStaticField" }!!
+
+            return UTest(listOf(), UTestStaticMethodCall(jcMethod, emptyList()))
+        }
+    }
 }


### PR DESCRIPTION
In JVM bytecode (and in `JcRawInst`) static fields can be accessed via child class. That causes bytecode transformation of the added `example.ParentStaticFieldUser` class to fail with the following exception, this PR fixes that issue.

```
java.lang.IllegalStateException: Field not found
	at org.usvm.instrumentation.instrumentation.JcInstructionTracer.encodeStaticFieldAccess(JcInstructionTracer.kt:133)
	at org.usvm.instrumentation.instrumentation.JcRuntimeTraceInstrumenter.instrumentMethod(JcRuntimeTraceInstrumenter.kt:66)
	at org.usvm.instrumentation.instrumentation.JcRuntimeTraceInstrumenter.instrumentClass(JcRuntimeTraceInstrumenter.kt:94)
	at org.usvm.instrumentation.agent.ClassTransformer.transform(ClassTransformer.kt:42)
	at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:244)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:541)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1013)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at org.usvm.instrumentation.classloader.WorkerClassLoader.findClass(WorkerClassLoader.kt:109)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at org.usvm.instrumentation.classloader.WorkerClassLoader.loadClass(WorkerClassLoader.kt:89)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:488)
	at java.base/java.lang.Class.forName(Class.java:467)
	at org.usvm.instrumentation.util.JacodbKt.toJavaMethod(Jacodb.kt:138)
	at org.usvm.instrumentation.testcase.executor.UTestExpressionExecutor.executeUTestStaticMethodCall(UTestExpressionExecutor.kt:293)
	at org.usvm.instrumentation.testcase.executor.UTestExpressionExecutor.exec(UTestExpressionExecutor.kt:66)
	at org.usvm.instrumentation.testcase.executor.UTestExpressionExecutor.executeUTestInst-IoAF18A(UTestExpressionExecutor.kt:39)
	at org.usvm.instrumentation.rd.UTestExecutor.executeUTest(UTestExecutor.kt:96)
	at org.usvm.instrumentation.rd.InstrumentedProcess.callUTest(InstrumentedProcess.kt:204)
	at org.usvm.instrumentation.rd.InstrumentedProcess.access$callUTest(InstrumentedProcess.kt:33)
	at org.usvm.instrumentation.rd.InstrumentedProcess$setup$1.invoke(InstrumentedProcess.kt:136)
	at org.usvm.instrumentation.rd.InstrumentedProcess$setup$1.invoke(InstrumentedProcess.kt:134)
	at org.usvm.instrumentation.rd.InstrumentedProcess$measureExecutionForTermination$1.invoke(InstrumentedProcess.kt:219)
	at com.jetbrains.rd.framework.IRdEndpoint$set$1.invoke(TaskInterfaces.kt:182)
	at com.jetbrains.rd.framework.IRdEndpoint$set$1.invoke(TaskInterfaces.kt:182)
	at com.jetbrains.rd.framework.impl.RdCall.onWireReceived(RdTask.kt:365)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2$2.invoke(MessageBroker.kt:57)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2$2.invoke(MessageBroker.kt:56)
	at com.jetbrains.rd.framework.impl.ProtocolContexts.readMessageContextAndInvoke(ProtocolContexts.kt:148)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2.invoke(MessageBroker.kt:56)
	at com.jetbrains.rd.framework.MessageBroker$invoke$2.invoke(MessageBroker.kt:54)
	at com.jetbrains.rd.util.threading.SingleThreadSchedulerBase.queue$lambda-3(SingleThreadScheduler.kt:41)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```