### PR TITLE
Fix API-dependency on kotlinx-collections

### DIFF
--- a/usvm-core/build.gradle.kts
+++ b/usvm-core/build.gradle.kts
@@ -8,8 +8,8 @@ dependencies {
     api("io.ksmt:ksmt-core:${Versions.ksmt}")
     api("io.ksmt:ksmt-z3:${Versions.ksmt}")
     api("io.github.microutils:kotlin-logging:${Versions.klogging}")
+    api("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:${Versions.collections}")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:${Versions.collections}")
     testImplementation("io.mockk:mockk:${Versions.mockk}")
     testImplementation("org.junit.jupiter:junit-jupiter-params:${Versions.junitParams}")
 


### PR DESCRIPTION
This PR changes the dependency on "kotlinx-collections-immutable" from `implementation` to `api`.

`persistentHashMapOf()` is being used as default argument in constructors in many PUBLIC classes, making it a part of a public API of USVM. In order to use such public constructors from outside, the user have to also depend on "kotlinx-collections-immutable" by himself. It is better to fix it "on our side" by marking the dependency "api".