### PR TITLE
Remove dependency on 'jvm-dataflow' in 'usvm-jvm' module

### DIFF
--- a/usvm-jvm/build.gradle.kts
+++ b/usvm-jvm/build.gradle.kts
@@ -26,7 +26,6 @@ val approximationsVersion = "0f081f101e"
 
 dependencies {
     implementation(project(":usvm-core"))
-    implementation(project(":usvm-jvm-dataflow"))
 
     implementation("${Versions.jacodbPackage}:jacodb-api-jvm:${Versions.jacodb}")
     implementation("${Versions.jacodbPackage}:jacodb-core:${Versions.jacodb}")

--- a/usvm-jvm/src/main/kotlin/org/usvm/machine/JcApplicationGraph.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/machine/JcApplicationGraph.kt
@@ -4,51 +4,69 @@ import org.jacodb.api.jvm.JcClasspath
 import org.jacodb.api.jvm.JcMethod
 import org.jacodb.api.jvm.JcTypedMethod
 import org.jacodb.api.jvm.cfg.JcInst
+import org.jacodb.api.jvm.ext.cfg.callExpr
 import org.jacodb.api.jvm.ext.toType
 import org.jacodb.impl.features.HierarchyExtensionImpl
 import org.jacodb.impl.features.SyncUsagesExtension
-import org.usvm.dataflow.jvm.graph.JcApplicationGraphImpl
 import org.usvm.statistics.ApplicationGraph
 import org.usvm.util.originalInst
 import java.util.concurrent.ConcurrentHashMap
 
-/**
- * A [JcApplicationGraphImpl] wrapper.
- */
 class JcApplicationGraph(
     cp: JcClasspath,
 ) : ApplicationGraph<JcMethod, JcInst> {
-    private val jcApplicationGraph = JcApplicationGraphImpl(cp, SyncUsagesExtension(HierarchyExtensionImpl(cp), cp))
+    private val usages = SyncUsagesExtension(HierarchyExtensionImpl(cp), cp)
 
     override fun predecessors(node: JcInst): Sequence<JcInst> {
-        return jcApplicationGraph.predecessors(node.originalInst())
+        @Suppress("NAME_SHADOWING")
+        val node = node.originalInst()
+        val graph = node.location.method.flowGraph()
+        val predecessors = graph.predecessors(node)
+        val throwers = graph.throwers(node)
+        return predecessors.asSequence() + throwers.asSequence()
     }
 
     override fun successors(node: JcInst): Sequence<JcInst> {
-        return jcApplicationGraph.successors(node.originalInst())
+        @Suppress("NAME_SHADOWING")
+        val node = node.originalInst()
+        val graph = node.location.method.flowGraph()
+        val successors = graph.successors(node)
+        val catchers = graph.catchers(node)
+        return successors.asSequence() + catchers.asSequence()
     }
 
     override fun callees(node: JcInst): Sequence<JcMethod> {
-        return jcApplicationGraph.callees(node.originalInst())
+        @Suppress("NAME_SHADOWING")
+        val node = node.originalInst()
+        val callExpr = node.callExpr ?: return emptySequence()
+        return sequenceOf(callExpr.method.method)
     }
 
-    override fun callers(method: JcMethod): Sequence<JcInst> =
-        jcApplicationGraph.callers(method)
+    override fun callers(method: JcMethod): Sequence<JcInst> {
+        return usages.findUsages(method).flatMap {
+            it.flowGraph().instructions.asSequence().filter { inst ->
+                val callExpr = inst.callExpr ?: return@filter false
+                callExpr.method.method == method
+            }
+        }
+    }
 
-    override fun entryPoints(method: JcMethod): Sequence<JcInst> =
-        jcApplicationGraph.entryPoints(method)
+    override fun entryPoints(method: JcMethod): Sequence<JcInst> {
+        return method.flowGraph().entries.asSequence()
+    }
 
-    override fun exitPoints(method: JcMethod): Sequence<JcInst> =
-        jcApplicationGraph.exitPoints(method)
+    override fun exitPoints(method: JcMethod): Sequence<JcInst> {
+        return method.flowGraph().exits.asSequence()
+    }
 
     override fun methodOf(node: JcInst): JcMethod {
-        return jcApplicationGraph.methodOf(node.originalInst())
+        return node.location.method
     }
 
     private val typedMethodsCache = ConcurrentHashMap<JcMethod, JcTypedMethod>()
 
     val JcMethod.typed: JcTypedMethod
-        get() = typedMethodsCache.getOrPut(this) {
+        get() = typedMethodsCache.computeIfAbsent(this) {
             enclosingClass.toType().declaredMethods.first { it.method == this }
         }
 
@@ -56,7 +74,7 @@ class JcApplicationGraph(
 
     override fun statementsOf(method: JcMethod): Sequence<JcInst> =
         statementsOfMethodCache
-            .getOrPut(method) { computeAllStatementsOfMethod(method) }
+            .computeIfAbsent(method) { computeAllStatementsOfMethod(method) }
             .asSequence()
 
     private fun computeAllStatementsOfMethod(method: JcMethod): Collection<JcInst> {


### PR DESCRIPTION
This PR inlines `JcApplicationGraphImpl` (from `usvm-dataflow-jvm` module, originally from `jacodb-analysis`) into `JcApplicationGraph` (in `uvsm-jvm` module, package `org.usvm.machine`). This allows for removing the dependency on `usvm-dataflow-jvm` module in `usvm-jvm`.