### PR TITLE
Enable tests by fixing the filtering of "check" task dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/DetektConfiguration.kt
+++ b/buildSrc/src/main/kotlin/DetektConfiguration.kt
@@ -79,6 +79,6 @@ fun Project.configureDetekt() {
     }
 
     tasks.named("check").configure {
-        setDependsOn(dependsOn.filter { it is TaskProvider<*> && it.name != "detekt" })
+        setDependsOn(dependsOn.filterNot { it is TaskProvider<*> && it.name == "detekt" })
     }
 }


### PR DESCRIPTION
This PR fixes the execution of tests on `gradle build` execution.

Previous code was retaining only TASKS (`it is TaskProvider`), excluding the "detekt" task. However, since "test tasks" are not exactly `TaskProvider`, but "TestSuite", all tests were also "unintentionally" filtered out.

You can debug it yourself by the following code in `DetektConfiguration.kt`:
```
tasks.named("check").configure {
    println("task = $this")
    println("dependsOn: ${dependsOn.toList()}")
    for (dep in dependsOn) {
        println("- ${dep::class.java}")
    }
    println("filtered: ${dependsOn.filter { it is TaskProvider<*> && it.name != "detekt" }}")
    setDependsOn(dependsOn.filterNot { it is TaskProvider<*> && it.name == "detekt" })
}
```

If the filtering of tests was actually intentional, it should be documented in comments to this configuration at least.

---

Note that the build is failing now due to the failing tests that was not run in CI for a long time. I confirm that `gradle test` also fails locally.