### PR TITLE
Enable `ConcreteExecutorTests.static interface method call test()`

### DIFF
--- a/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
+++ b/usvm-jvm-instrumentation/src/test/kotlin/org/usvm/instrumentation/executor/ConcreteExecutorTests.kt
@@ -116,7 +116,6 @@ class ConcreteExecutorTests: UTestConcreteExecutorTest() {
     }
 
     @Test
-    @Disabled
     fun `static interface method call test`() = executeTest {
         val uTest = UTestCreator.StaticInterfaceMethodCall.callStaticInterfaceMethod(jcClasspath)
         val res = uTestConcreteExecutor.executeAsync(uTest)


### PR DESCRIPTION
Test from https://github.com/UnitTestBot/usvm/pull/173 no longer fails