### PR TITLE
Add State bound for UMachine

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/Machine.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Machine.kt
@@ -14,7 +14,7 @@ val logger = object : KLogging() {}.logger
  *
  * @see [run]
  */
-abstract class UMachine<State : UState<*, *, *, *, *, *>> : AutoCloseable {
+abstract class UMachine<State : UState<*, *, *, *, *, State>> : AutoCloseable {
     /**
      * Runs symbolic execution loop.
      *


### PR DESCRIPTION
This PR adds the missing `State` bound in the recursive generic in `UMachine`.

This change allows for performing `State`-related operations on `state: State`. Most notably, `clone()` correctly returns the generic `State`, not just the base `UState<*>`.