### PR TITLE
Avoid calling JcClass.methods in instrumentation

### DIFF
--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/TraceDeserializer.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/TraceDeserializer.kt
@@ -1,0 +1,34 @@
+package org.usvm.instrumentation.executor
+
+import org.jacodb.api.jvm.JcClassOrInterface
+import org.jacodb.api.jvm.JcClasspath
+import org.jacodb.api.jvm.cfg.JcInst
+import org.jacodb.api.jvm.ext.methods
+import org.usvm.instrumentation.generated.models.ClassToId
+import kotlin.math.pow
+
+class TraceDeserializer(private val jcClasspath: JcClasspath) {
+    private val deserializedInstructionsCache = HashMap<Long, JcInst>()
+    private val deserializedClassesCache = HashMap<Long, JcClassOrInterface>()
+
+    fun deserializeTrace(trace: List<Long>, coveredClasses: List<ClassToId>): List<JcInst> =
+        trace.map { encodedInst ->
+            deserializedInstructionsCache.getOrPut(encodedInst) {
+                val classIdOffset = (2.0.pow(Byte.SIZE_BITS * 3).toLong() - 1) shl (Byte.SIZE_BITS * 5 - 1)
+                val classId = encodedInst and classIdOffset shr (Byte.SIZE_BITS * 5)
+                val methodIdOffset = (2.0.pow(Byte.SIZE_BITS * 2).toLong() - 1) shl (Byte.SIZE_BITS * 3 - 1)
+                val methodId = encodedInst and methodIdOffset shr (Byte.SIZE_BITS * 3)
+                val instructionId = (encodedInst and (2.0.pow(Byte.SIZE_BITS * 3).toLong() - 1)).toInt()
+                val jcClass =
+                    deserializedClassesCache.getOrPut(classId) {
+                        val className = coveredClasses.find { it.classId == classId }
+                            ?: error("Deserialization error")
+                        jcClasspath.findClassOrNull(className.className) ?: error("Deserialization error")
+                    }
+                val jcMethod = jcClass.methods.sortedBy { it.description }[methodId.toInt()]
+                jcMethod.instList
+                    .find { it.location.index == instructionId }
+                    ?: error("Deserialization error")
+            }
+        }
+}

--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/TraceDeserializer.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/executor/TraceDeserializer.kt
@@ -3,7 +3,6 @@ package org.usvm.instrumentation.executor
 import org.jacodb.api.jvm.JcClassOrInterface
 import org.jacodb.api.jvm.JcClasspath
 import org.jacodb.api.jvm.cfg.JcInst
-import org.jacodb.api.jvm.ext.methods
 import org.usvm.instrumentation.generated.models.ClassToId
 import kotlin.math.pow
 
@@ -25,7 +24,7 @@ class TraceDeserializer(private val jcClasspath: JcClasspath) {
                             ?: error("Deserialization error")
                         jcClasspath.findClassOrNull(className.className) ?: error("Deserialization error")
                     }
-                val jcMethod = jcClass.methods.sortedBy { it.description }[methodId.toInt()]
+                val jcMethod = jcClass.declaredMethods.sortedBy { it.description }[methodId.toInt()]
                 jcMethod.instList
                     .find { it.location.index == instructionId }
                     ?: error("Deserialization error")

--- a/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/instrumentation/JcInstructionTracer.kt
+++ b/usvm-jvm-instrumentation/src/main/kotlin/org/usvm/instrumentation/instrumentation/JcInstructionTracer.kt
@@ -6,7 +6,6 @@ import org.jacodb.api.jvm.JcField
 import org.jacodb.api.jvm.JcMethod
 import org.jacodb.api.jvm.cfg.JcInst
 import org.jacodb.api.jvm.cfg.JcRawFieldRef
-import org.jacodb.api.jvm.ext.methods
 import org.usvm.instrumentation.collector.trace.TraceCollector
 import org.usvm.instrumentation.instrumentation.JcInstructionTracer.StaticFieldAccessType
 import org.usvm.instrumentation.util.enclosingClass
@@ -75,7 +74,7 @@ object JcInstructionTracer : Tracer<Trace> {
 
     private fun encodeMethod(jcClass: JcClassOrInterface, jcMethod: JcMethod): EncodedMethod {
         val encodedClass = encodeClass(jcClass)
-        val methodIndex = jcClass.methods
+        val methodIndex = jcClass.declaredMethods
             .sortedBy { it.description }
             .indexOf(jcMethod)
             .also { if (it == -1) error("Encoding error") }


### PR DESCRIPTION
Needed to run instrumentation with empty folder as JRE