### PR TITLE
Add flow-less summary storage

### DIFF
--- a/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/ifds/Producer.kt
+++ b/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/ifds/Producer.kt
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.usvm.dataflow.ifds
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+interface Producer<T> {
+    fun produce(event: T)
+    fun subscribe(consumer: Consumer<T>)
+}
+
+fun interface Consumer<in T> {
+    fun consume(event: T)
+}
+
+class SyncProducer<T> : Producer<T> {
+    private val consumers: MutableList<Consumer<T>> = mutableListOf()
+    private val events: MutableList<T> = mutableListOf()
+
+    @Synchronized
+    override fun produce(event: T) {
+        for (consumer in consumers) {
+            consumer.consume(event)
+        }
+        events.add(event)
+    }
+
+    @Synchronized
+    override fun subscribe(consumer: Consumer<T>) {
+        for (event in events) {
+            consumer.consume(event)
+        }
+        consumers.add(consumer)
+    }
+}
+
+sealed interface ConsList<out T> : Iterable<T>
+
+data object Nil : ConsList<Nothing> {
+    override fun iterator(): Iterator<Nothing> = object : Iterator<Nothing> {
+        override fun hasNext(): Boolean = false
+        override fun next(): Nothing = throw NoSuchElementException()
+    }
+}
+
+data class Cons<out T>(
+    val value: T,
+    val tail: ConsList<T>,
+) : ConsList<T> {
+    override fun iterator(): Iterator<T> = Iter(this)
+
+    private class Iter<T>(private var list: ConsList<T>) : Iterator<T> {
+        override fun hasNext(): Boolean = list !is Nil
+
+        override fun next(): T = when (val list = list) {
+            is Nil -> throw NoSuchElementException()
+            is Cons -> {
+                val value = list.value
+                this.list = list.tail
+                value
+            }
+        }
+    }
+}
+
+class NonBlockingQueue<T> {
+    data class Node<T>(
+        val value: T,
+        @Volatile var next: Node<T>? = null,
+    )
+
+    var head: Node<T>? = null
+        private set
+    val tail: AtomicReference<Node<T>> = AtomicReference(head)
+    val size: AtomicInteger = AtomicInteger(0)
+
+    fun add(element: T) {
+        val node = Node(element)
+        var currentTail: Node<T>?
+        while (true) {
+            currentTail = tail.get()
+            if (tail.compareAndSet(currentTail, node)) break
+        }
+        if (currentTail != null) {
+            currentTail.next = node
+        } else {
+            head = node
+        }
+        size.incrementAndGet()
+    }
+}
+
+class ConcurrentProducer<T> : Producer<T> {
+    private var consumers: AtomicReference<ConsList<Consumer<T>>> = AtomicReference(Nil)
+    private val events: NonBlockingQueue<T> = NonBlockingQueue()
+
+    override fun produce(event: T) {
+        var currentConsumers: ConsList<Consumer<T>>
+        while (true) {
+            currentConsumers = consumers.get() ?: continue
+            if (consumers.compareAndSet(currentConsumers, null)) break
+        }
+
+        events.add(event)
+
+        try {
+            for (consumer in currentConsumers) {
+                consumer.consume(event)
+            }
+        } finally {
+            check(consumers.compareAndSet(null, currentConsumers))
+        }
+    }
+
+    override fun subscribe(consumer: Consumer<T>) {
+        var last: NonBlockingQueue.Node<T>? = null
+        while (true) {
+            val start = if (last != null) last.next else events.head
+            var current = start
+            while (current != null) {
+                last = current
+                consumer.consume(current.value)
+                current = current.next
+            }
+
+            val currentConsumers = consumers.get() ?: continue
+            if (!consumers.compareAndSet(currentConsumers, null)) continue
+            if (events.tail.get() === last) {
+                val newConsumers = Cons(consumer, currentConsumers)
+                check(consumers.compareAndSet(null, newConsumers))
+                break
+            } else {
+                check(consumers.compareAndSet(null, currentConsumers))
+            }
+        }
+    }
+}

--- a/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/ifds/Runner.kt
+++ b/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/ifds/Runner.kt
@@ -114,6 +114,7 @@ class UniRunner<Fact, Event, Method, Statement>(
 
             // Add edge to worklist:
             workList.trySend(edge).getOrThrow()
+            manager.handleControlEvent(queueIsNotEmpty)
 
             return true
         }
@@ -126,7 +127,6 @@ class UniRunner<Fact, Event, Method, Statement>(
             val edge = workList.tryReceive().getOrElse {
                 manager.handleControlEvent(queueIsEmpty)
                 val edge = workList.receive()
-                manager.handleControlEvent(queueIsNotEmpty)
                 edge
             }
             tabulationAlgorithmStep(edge, this@coroutineScope)

--- a/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintAnalyzers.kt
+++ b/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintAnalyzers.kt
@@ -27,6 +27,7 @@ import org.usvm.dataflow.config.FactAwareConditionEvaluator
 import org.usvm.dataflow.ifds.Analyzer
 import org.usvm.dataflow.ifds.Edge
 import org.usvm.dataflow.ifds.Reason
+import org.usvm.dataflow.ifds.UnitResolver
 import org.usvm.dataflow.util.Traits
 
 private val logger = object : KLogging() {}.logger
@@ -34,13 +35,14 @@ private val logger = object : KLogging() {}.logger
 context(Traits<Method, Statement>)
 class TaintAnalyzer<Method, Statement>(
     private val graph: ApplicationGraph<Method, Statement>,
+    private val unitResolver: UnitResolver<Method>,
     private val getConfigForMethod: (Method) -> List<TaintConfigurationItem>?,
 ) : Analyzer<TaintDomainFact, TaintEvent<Statement>, Method, Statement>
     where Method : CommonMethod,
           Statement : CommonInst {
 
     override val flowFunctions: ForwardTaintFlowFunctions<Method, Statement> by lazy {
-        ForwardTaintFlowFunctions(graph, getConfigForMethod)
+        ForwardTaintFlowFunctions(graph, unitResolver, getConfigForMethod)
     }
 
     private fun isExitPoint(statement: Statement): Boolean {

--- a/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintBidiRunner.kt
+++ b/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintBidiRunner.kt
@@ -20,6 +20,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import org.jacodb.api.common.CommonMethod
+import org.jacodb.api.common.analysis.ApplicationGraph
+import org.jacodb.api.common.cfg.CommonInst
 import org.usvm.dataflow.ifds.ControlEvent
 import org.usvm.dataflow.ifds.Edge
 import org.usvm.dataflow.ifds.IfdsResult
@@ -28,9 +31,6 @@ import org.usvm.dataflow.ifds.QueueEmptinessChanged
 import org.usvm.dataflow.ifds.Reason
 import org.usvm.dataflow.ifds.UnitResolver
 import org.usvm.dataflow.ifds.UnitType
-import org.jacodb.api.common.CommonMethod
-import org.jacodb.api.common.analysis.ApplicationGraph
-import org.jacodb.api.common.cfg.CommonInst
 
 class TaintBidiRunner<Method, Statement>(
     val manager: TaintManager<Method, Statement>,

--- a/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintFlowFunctions.kt
+++ b/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintFlowFunctions.kt
@@ -45,6 +45,8 @@ import org.usvm.dataflow.config.TaintActionEvaluator
 import org.usvm.dataflow.ifds.ElementAccessor
 import org.usvm.dataflow.ifds.FlowFunction
 import org.usvm.dataflow.ifds.FlowFunctions
+import org.usvm.dataflow.ifds.UnitResolver
+import org.usvm.dataflow.ifds.UnknownUnit
 import org.usvm.dataflow.ifds.isOnHeap
 import org.usvm.dataflow.ifds.isStatic
 import org.usvm.dataflow.ifds.minus
@@ -57,6 +59,7 @@ private val logger = mu.KotlinLogging.logger {}
 context(Traits<Method, Statement>)
 class ForwardTaintFlowFunctions<Method, Statement>(
     private val graph: ApplicationGraph<Method, Statement>,
+    private val unitResolver: UnitResolver<Method>,
     val getConfigForMethod: (Method) -> List<TaintConfigurationItem>?,
 ) : FlowFunctions<TaintDomainFact, Method, Statement>
     where Method : CommonMethod,
@@ -321,7 +324,7 @@ class ForwardTaintFlowFunctions<Method, Statement>(
         //    to remove any marks from 'instance' and arguments.
         //   Currently, "analyzability" of the callee depends on the fact that the callee
         //    is "accessible" through the JcApplicationGraph::callees().
-        if (callee in graph.callees(callStatement)) {
+        if (callee in graph.callees(callStatement) && unitResolver.resolve(callee) != UnknownUnit) {
 
             if (fact.variable.isStatic) {
                 return@FlowFunction emptyList()

--- a/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintManager.kt
+++ b/usvm-dataflow/src/main/kotlin/org/usvm/dataflow/taint/TaintManager.kt
@@ -177,8 +177,8 @@ open class TaintManager<Method, Statement>(
 
             // Start the runner:
             launch(start = CoroutineStart.LAZY) {
-                val methods = methodsForUnit[unit]!!.toList()
-                runner.run(methods)
+                val methods = methodsForUnit[unit]!!
+                runner.run(startMethods.filter { it in methods })
             }
         }
 

--- a/usvm-jvm-dataflow/build.gradle.kts
+++ b/usvm-jvm-dataflow/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     implementation(Libs.sarif4k)
 
+    testImplementation(Libs.logback)
     testImplementation(Libs.mockk)
     testImplementation(Libs.junit_jupiter_params)
 

--- a/usvm-jvm-dataflow/src/main/kotlin/org/usvm/dataflow/jvm/npe/NpeFlowFunctions.kt
+++ b/usvm-jvm-dataflow/src/main/kotlin/org/usvm/dataflow/jvm/npe/NpeFlowFunctions.kt
@@ -16,9 +16,6 @@
 
 package org.usvm.dataflow.jvm.npe
 
-import org.jacodb.api.common.cfg.CommonAssignInst
-import org.jacodb.api.common.cfg.CommonExpr
-import org.jacodb.api.common.cfg.CommonValue
 import org.jacodb.api.jvm.JcArrayType
 import org.jacodb.api.jvm.JcClasspath
 import org.jacodb.api.jvm.JcMethod
@@ -130,12 +127,9 @@ class ForwardNpeFlowFunctions(
 
     private fun transmitTaintAssign(
         fact: Tainted,
-        from: CommonExpr,
-        to: CommonValue,
+        from: JcExpr,
+        to: JcValue,
     ): Collection<Tainted> {
-        from as JcExpr
-        to as JcValue
-
         val toPath = convertToPath(to)
         val fromPath = convertToPathOrNull(from)
 
@@ -197,8 +191,8 @@ class ForwardNpeFlowFunctions(
     private fun generates(
         inst: JcInst,
     ): Collection<TaintDomainFact> = buildList {
-        if (inst is CommonAssignInst) {
-            val toPath = convertToPath(inst.lhv as JcValue)
+        if (inst is JcAssignInst) {
+            val toPath = convertToPath(inst.lhv)
             val from = inst.rhv
             if (from is JcNullConstant || (from is JcCallExpr && from.method.method.isNullable == true)) {
                 add(Tainted(toPath, TaintMark.NULLNESS))

--- a/usvm-jvm-dataflow/src/main/kotlin/org/usvm/dataflow/jvm/npe/NpeManager.kt
+++ b/usvm-jvm-dataflow/src/main/kotlin/org/usvm/dataflow/jvm/npe/NpeManager.kt
@@ -58,14 +58,6 @@ class NpeManager(
         runnerForUnit[unit] = runner
         return runner
     }
-
-    override fun addStart(method: JcMethod) {
-        logger.info { "Adding start method: $method" }
-        val unit = unitResolver.resolve(method)
-        if (unit == UnknownUnit) return
-        methodsForUnit.getOrPut(unit) { hashSetOf() }.add(method)
-        // Note: DO NOT add deps here!
-    }
 }
 
 fun jcNpeManager(

--- a/usvm-jvm-dataflow/src/main/kotlin/org/usvm/dataflow/jvm/unused/UnusedVariableManager.kt
+++ b/usvm-jvm-dataflow/src/main/kotlin/org/usvm/dataflow/jvm/unused/UnusedVariableManager.kt
@@ -29,12 +29,15 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
+import org.jacodb.api.common.CommonMethod
+import org.jacodb.api.common.analysis.ApplicationGraph
+import org.jacodb.api.common.cfg.CommonInst
 import org.usvm.dataflow.ifds.ControlEvent
 import org.usvm.dataflow.ifds.Edge
 import org.usvm.dataflow.ifds.Manager
 import org.usvm.dataflow.ifds.QueueEmptinessChanged
 import org.usvm.dataflow.ifds.Runner
-import org.usvm.dataflow.ifds.SummaryStorageImpl
+import org.usvm.dataflow.ifds.SummaryStorageWithFlows
 import org.usvm.dataflow.ifds.UniRunner
 import org.usvm.dataflow.ifds.UnitResolver
 import org.usvm.dataflow.ifds.UnitType
@@ -42,9 +45,6 @@ import org.usvm.dataflow.ifds.UnknownUnit
 import org.usvm.dataflow.ifds.Vertex
 import org.usvm.dataflow.util.Traits
 import org.usvm.dataflow.util.getPathEdges
-import org.jacodb.api.common.CommonMethod
-import org.jacodb.api.common.analysis.ApplicationGraph
-import org.jacodb.api.common.cfg.CommonInst
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -65,7 +65,7 @@ class UnusedVariableManager<Method, Statement>(
     private val runnerForUnit: MutableMap<UnitType, Runner<UnusedVariableDomainFact, Method, Statement>> = hashMapOf()
     private val queueIsEmpty = ConcurrentHashMap<UnitType, Boolean>()
 
-    private val summaryEdgesStorage = SummaryStorageImpl<UnusedVariableSummaryEdge<Statement>>()
+    private val summaryEdgesStorage = SummaryStorageWithFlows<UnusedVariableSummaryEdge<Statement>>()
 
     private val stopRendezvous = Channel<Unit>(Channel.RENDEZVOUS)
 

--- a/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsNpeTest.kt
+++ b/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsNpeTest.kt
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.usvm.dataflow.jvm.graph.JcApplicationGraphImpl
-import org.usvm.dataflow.jvm.ifds.SingletonUnitResolver
+import org.usvm.dataflow.jvm.ifds.MethodUnitResolver
 import org.usvm.dataflow.jvm.npe.jcNpeManager
 import org.usvm.dataflow.taint.TaintVulnerability
 import java.util.StringTokenizer
@@ -193,7 +193,7 @@ class IfdsNpeTest : BaseAnalysisTest() {
     }
 
     private fun findSinks(method: JcMethod): List<TaintVulnerability<JcInst>> {
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = jcNpeManager(graph, unitResolver)
         return manager.analyze(listOf(method), timeout = 30.seconds)
     }

--- a/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsSqlTest.kt
+++ b/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsSqlTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.usvm.dataflow.jvm.ifds.ClassUnitResolver
-import org.usvm.dataflow.jvm.ifds.SingletonUnitResolver
+import org.usvm.dataflow.jvm.ifds.MethodUnitResolver
 import org.usvm.dataflow.jvm.taint.jcTaintManager
 import org.usvm.dataflow.jvm.util.JcTraits
 import org.usvm.dataflow.sarif.sarifReportFromVulnerabilities
@@ -54,7 +54,7 @@ class IfdsSqlTest : BaseAnalysisTest() {
         val methodName = "bad"
         val method = cp.findClass<SqlInjectionExamples>().declaredMethods.single { it.name == methodName }
         val methods = listOf(method)
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = jcTaintManager(graph, unitResolver)
         val sinks = manager.analyze(methods, timeout = 30.seconds)
         assertTrue(sinks.isNotEmpty())
@@ -68,7 +68,7 @@ class IfdsSqlTest : BaseAnalysisTest() {
     @MethodSource("provideClassesForJuliet89")
     fun `test on Juliet's CWE 89`(className: String) {
         testSingleJulietClass(className) { method ->
-            val unitResolver = SingletonUnitResolver
+            val unitResolver = MethodUnitResolver
             val manager = jcTaintManager(graph, unitResolver)
             manager.analyze(listOf(method), timeout = 30.seconds)
         }
@@ -78,7 +78,7 @@ class IfdsSqlTest : BaseAnalysisTest() {
     fun `test on specific Juliet instance`() {
         val className = "juliet.testcases.CWE89_SQL_Injection.s01.CWE89_SQL_Injection__connect_tcp_execute_01"
         testSingleJulietClass(className) { method ->
-            val unitResolver = SingletonUnitResolver
+            val unitResolver = MethodUnitResolver
             val manager = jcTaintManager(graph, unitResolver)
             manager.analyze(listOf(method), timeout = 30.seconds)
         }

--- a/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsTaintTest.kt
+++ b/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsTaintTest.kt
@@ -23,7 +23,7 @@ import org.jacodb.api.jvm.ext.findClass
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
-import org.usvm.dataflow.jvm.ifds.SingletonUnitResolver
+import org.usvm.dataflow.jvm.ifds.MethodUnitResolver
 import org.usvm.dataflow.jvm.taint.jcTaintManager
 import org.usvm.dataflow.taint.TaintVulnerability
 import kotlin.test.assertTrue
@@ -40,7 +40,7 @@ class IfdsTaintTest : BaseAnalysisTest() {
     }
 
     private fun findSinks(method: JcMethod): List<TaintVulnerability<JcInst>> {
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = jcTaintManager(graph, unitResolver)
         return manager.analyze(listOf(method), timeout = 3000.seconds)
     }

--- a/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsUntrustedLoopBoundTest.kt
+++ b/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsUntrustedLoopBoundTest.kt
@@ -22,7 +22,7 @@ import org.jacodb.api.jvm.ext.findClass
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
-import org.usvm.dataflow.jvm.ifds.SingletonUnitResolver
+import org.usvm.dataflow.jvm.ifds.MethodUnitResolver
 import org.usvm.dataflow.jvm.taint.jcTaintManager
 import org.usvm.dataflow.taint.TaintAnalysisOptions
 import kotlin.test.assertTrue
@@ -31,7 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 private val logger = KotlinLogging.logger {}
 
 @TestInstance(PER_CLASS)
-class Ifds2UpperBoundTest : BaseAnalysisTest(configFileName = "config_untrusted_loop_bound.json") {
+class IfdsUntrustedLoopBoundTest : BaseAnalysisTest(configFileName = "config_untrusted_loop_bound.json") {
 
     @Test
     fun `analyze untrusted upper bound`() {
@@ -41,7 +41,7 @@ class Ifds2UpperBoundTest : BaseAnalysisTest(configFileName = "config_untrusted_
 
     private inline fun <reified T> testOneMethod(methodName: String) {
         val method = cp.findClass<T>().declaredMethods.single { it.name == methodName }
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = jcTaintManager(graph, unitResolver)
         val sinks = manager.analyze(listOf(method), timeout = 60.seconds)
         logger.info { "Sinks: ${sinks.size}" }

--- a/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsUnusedTest.kt
+++ b/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/IfdsUnusedTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.usvm.dataflow.jvm.ifds.SingletonUnitResolver
+import org.usvm.dataflow.jvm.ifds.MethodUnitResolver
 import org.usvm.dataflow.jvm.unused.UnusedVariableManager
 import org.usvm.dataflow.jvm.util.JcTraits
 import java.util.stream.Stream
@@ -59,7 +59,7 @@ class IfdsUnusedTest : BaseAnalysisTest() {
     @MethodSource("provideClassesForJuliet563")
     fun `test on Juliet's CWE 563`(className: String) {
         testSingleJulietClass(className) { method ->
-            val unitResolver = SingletonUnitResolver
+            val unitResolver = MethodUnitResolver
             val manager = with(JcTraits(cp)) {
                 UnusedVariableManager(graph, unitResolver)
             }
@@ -73,7 +73,7 @@ class IfdsUnusedTest : BaseAnalysisTest() {
             "juliet.testcases.CWE563_Unused_Variable.CWE563_Unused_Variable__unused_init_variable_StringBuilder_01"
         val clazz = cp.findClass(className)
         val badMethod = clazz.methods.single { it.name == "bad" }
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = with(JcTraits(cp)) {
             UnusedVariableManager(graph, unitResolver)
         }

--- a/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/JodaDateTimeAnalysisTest.kt
+++ b/usvm-jvm-dataflow/src/test/kotlin/org/usvm/dataflow/jvm/impl/JodaDateTimeAnalysisTest.kt
@@ -21,7 +21,7 @@ import org.joda.time.DateTime
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
-import org.usvm.dataflow.jvm.ifds.SingletonUnitResolver
+import org.usvm.dataflow.jvm.ifds.MethodUnitResolver
 import org.usvm.dataflow.jvm.npe.jcNpeManager
 import org.usvm.dataflow.jvm.taint.jcTaintManager
 import org.usvm.dataflow.jvm.unused.UnusedVariableManager
@@ -37,7 +37,7 @@ class JodaDateTimeAnalysisTest : BaseAnalysisTest() {
     fun `test taint analysis`() {
         val clazz = cp.findClass<DateTime>()
         val methods = clazz.declaredMethods
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = jcTaintManager(graph, unitResolver)
         val sinks = manager.analyze(methods, timeout = 60.seconds)
         logger.info { "Vulnerabilities found: ${sinks.size}" }
@@ -47,7 +47,7 @@ class JodaDateTimeAnalysisTest : BaseAnalysisTest() {
     fun `test NPE analysis`() {
         val clazz = cp.findClass<DateTime>()
         val methods = clazz.declaredMethods
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = jcNpeManager(graph, unitResolver)
         val sinks = manager.analyze(methods, timeout = 60.seconds)
         logger.info { "Vulnerabilities found: ${sinks.size}" }
@@ -57,7 +57,7 @@ class JodaDateTimeAnalysisTest : BaseAnalysisTest() {
     fun `test unused variables analysis`() {
         val clazz = cp.findClass<DateTime>()
         val methods = clazz.declaredMethods
-        val unitResolver = SingletonUnitResolver
+        val unitResolver = MethodUnitResolver
         val manager = with(JcTraits(cp)) {
             UnusedVariableManager(graph, unitResolver)
         }


### PR DESCRIPTION
This PR proposes to add a summary storage without Flow's, which allows for deterministic (non-asynchronous!) subscriptions on summary edges.
Ultimately, this enables us to use `MethodUnitResolver` without any doubts, which currently is not very possible to due the fact that method-bound runners might die (i.e. might be killed by the manager) due to their queue exhaustion before the subscription on summary edges will be handled by the separate spawned coroutine (`launch` + `SharedFlow::collect`).

Moved from https://github.com/UnitTestBot/jacodb/pull/222.