### PR TITLE
Move detekt to a separate job in CI workflow

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -72,11 +72,27 @@ jobs:
         run: |
           ./gradlew build --no-daemon -PcpythonActivated=true
 
-      - name: Run Detekt
-        run: |
-          ./gradlew detektMain detektTest --no-daemon
+  detekt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: "true"
 
-      - name: Upload SARIF to GitHub
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run Detekt
+        run: ./gradlew detektMain detektTest
+
+      - name: Upload Detekt SARIF report
         uses: github/codeql-action/upload-sarif@v3
         if: success() || failure()
         with:


### PR DESCRIPTION
This PR moves the step with detekt run from the `build` job into a separate job, allowing it to execute in parallel on CI.