### PR TITLE
Rename TsValue

### DIFF
--- a/usvm-ts/src/main/kotlin/org/usvm/api/TsTest.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/api/TsTest.kt
@@ -9,62 +9,53 @@ data class TsTest(
     val method: EtsMethod,
     val before: TsParametersState,
     val after: TsParametersState,
-    val returnValue: TsObject,
+    val returnValue: TsValue,
     val trace: List<EtsStmt>? = null,
 )
 
 data class TsParametersState(
-    val thisInstance: TsObject?,
-    val parameters: List<TsObject>,
+    val thisInstance: TsValue?,
+    val parameters: List<TsValue>,
     val globals: Map<EtsClass, List<GlobalFieldValue>>,
 )
 
-data class GlobalFieldValue(val field: EtsField, val value: TsObject) // TODO is it right?????
+data class GlobalFieldValue(val field: EtsField, val value: TsValue) // TODO is it right?????
 
 open class TsMethodCoverage
 
 object NoCoverage : TsMethodCoverage()
 
-sealed interface TsObject {
-    sealed interface TsNumber : org.usvm.api.TsObject {
-        data class Integer(val value: Int) : TsNumber
+sealed interface TsValue {
+    data object TsAny : TsValue
+    data object TsUnknown : TsValue
+    data object TsNull : TsValue
+    data object TsUndefined : TsValue
+    data object TsException : TsValue
 
-        data class Double(val value: kotlin.Double) : TsNumber
+    data class TsBoolean(val value: Boolean) : TsValue
+    data class TsString(val value: String) : TsValue
+    data class TsBigInt(val value: String) : TsValue
 
-        val number: kotlin.Double
-            get() = when (this) {
-                is Integer -> value.toDouble()
-                is Double -> value
-            }
+    sealed interface TsNumber : TsValue {
+        data class TsInteger(val value: Int) : TsNumber
 
-        val truthyValue: Boolean
-            get() = number != 0.0 && !number.isNaN()
-    }
+        data class TsDouble(val value: Double) : TsNumber
 
-    data class TsString(val value: String) : org.usvm.api.TsObject
-
-    data class TsBoolean(val value: Boolean) : org.usvm.api.TsObject {
         val number: Double
-            get() = if (value) 1.0 else 0.0
+            get() = when (this) {
+                is TsInteger -> value.toDouble()
+                is TsDouble -> value
+            }
     }
 
-    data class TsBigInt(val value: String) : org.usvm.api.TsObject
+    data class TsObject(val addr: Int) : TsValue
 
-    data class TsClass(val name: String, val properties: Map<String, org.usvm.api.TsObject>) :
-        org.usvm.api.TsObject
+    data class TsClass(
+        val name: String,
+        val properties: Map<String, TsValue>,
+    ) : TsValue
 
-    data object TsAny : org.usvm.api.TsObject
-
-    data object TsUndefinedObject : org.usvm.api.TsObject
-
-    data class TsArray(val values: List<org.usvm.api.TsObject>) :
-        org.usvm.api.TsObject
-
-    data class TsObject(val addr: Int) : org.usvm.api.TsObject
-
-    data object TsUnknown : org.usvm.api.TsObject
-
-    data object TsNull : org.usvm.api.TsObject
-
-    data object TsException : org.usvm.api.TsObject
+    data class TsArray(
+        val values: List<TsValue>,
+    ) : TsValue
 }

--- a/usvm-ts/src/main/kotlin/org/usvm/machine/state/TsState.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/machine/state/TsState.kt
@@ -13,12 +13,12 @@ import org.usvm.api.targets.TsTarget
 import org.usvm.collections.immutable.getOrPut
 import org.usvm.collections.immutable.implementations.immutableMap.UPersistentHashMap
 import org.usvm.collections.immutable.internal.MutabilityOwnership
+import org.usvm.collections.immutable.persistentHashMapOf
 import org.usvm.constraints.UPathConstraints
 import org.usvm.machine.TsContext
 import org.usvm.memory.UMemory
 import org.usvm.model.UModelBase
 import org.usvm.targets.UTargetsSet
-import org.usvm.collections.immutable.persistentHashMapOf
 
 class TsState(
     ctx: TsContext,

--- a/usvm-ts/src/main/kotlin/org/usvm/util/Utils.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/util/Utils.kt
@@ -15,7 +15,6 @@ import org.usvm.machine.state.TsState
 fun TsContext.boolToFp(expr: UExpr<UBoolSort>): UExpr<KFp64Sort> =
     mkIte(expr, mkFp64(1.0), mkFp64(0.0))
 
-
 // TODO probably this should be written differently
 fun EtsScene.fieldLookUp(field: EtsFieldSignature) = projectAndSdkClasses
     .first { it.signature == field.enclosingClass }

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/And.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/And.kt
@@ -35,7 +35,7 @@ import org.jacodb.ets.utils.getLocals
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 import org.usvm.util.isTruthy
@@ -59,7 +59,7 @@ class And : TsMethodTestRunner() {
     @Test
     fun `test andOfBooleanAndBoolean`() {
         val method = getMethod("And", "andOfBooleanAndBoolean")
-        discoverProperties<TsObject.TsBoolean, TsObject.TsBoolean, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBoolean, TsValue.TsBoolean, TsValue.TsNumber>(
             method = method,
             { a, b, r -> a.value && b.value && r.number == 1.0 },
             { a, b, r -> a.value && !b.value && r.number == 2.0 },
@@ -107,7 +107,7 @@ class And : TsMethodTestRunner() {
         method._cfg = etsCfg
         locals += method.getLocals()
 
-        discoverProperties<TsObject.TsBoolean, TsObject.TsBoolean, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBoolean, TsValue.TsBoolean, TsValue.TsNumber>(
             method = method,
             { a, b, r -> a.value && b.value && r.number == 1.0 },
             { a, b, r -> a.value && !b.value && r.number == 2.0 },
@@ -232,7 +232,7 @@ class And : TsMethodTestRunner() {
         method._cfg = EtsCfg(statements, successorMap)
         locals += method.getLocals()
 
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber>(
             method = method,
             { a, b, r -> isTruthy(a) && isTruthy(b) && r.number == 1.0 },
             { a, b, r -> isTruthy(a) && b.number.isNaN() && r.number == 2.0 },
@@ -335,7 +335,7 @@ class And : TsMethodTestRunner() {
         method._cfg = EtsCfg(statements, successorMap)
         locals += method.getLocals()
 
-        discoverProperties<TsObject.TsBoolean, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBoolean, TsValue.TsNumber, TsValue.TsNumber>(
             method = method,
             { a, b, r -> a.value && isTruthy(b) && r.number == 1.0 },
             { a, b, r -> a.value && b.number.isNaN() && r.number == 2.0 },
@@ -435,7 +435,7 @@ class And : TsMethodTestRunner() {
         method._cfg = EtsCfg(statements, successorMap)
         locals += method.getLocals()
 
-        discoverProperties<TsObject.TsNumber, TsObject.TsBoolean, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsBoolean, TsValue.TsNumber>(
             method = method,
             { a, b, r -> isTruthy(a) && b.value && r.number == 1.0 },
             { a, b, r -> isTruthy(a) && !b.value && r.number == 2.0 },
@@ -450,7 +450,7 @@ class And : TsMethodTestRunner() {
     @Disabled("Does not work because objects cannot be null")
     fun `test andOfObjectAndObject`() {
         val method = getMethod("And", "andOfObjectAndObject")
-        discoverProperties<TsObject.TsClass, TsObject.TsClass, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsClass, TsValue.TsClass, TsValue.TsNumber>(
             method = method,
             { a, b, r -> isTruthy(a) && isTruthy(b) && r.number == 1.0 },
             { a, b, r -> isTruthy(a) && !isTruthy(b) && r.number == 2.0 },
@@ -462,25 +462,25 @@ class And : TsMethodTestRunner() {
     @Test
     fun `test andOfUnknown`() {
         val method = getMethod("And", "andOfUnknown")
-        discoverProperties<TsObject, TsObject, TsObject.TsNumber>(
+        discoverProperties<TsValue, TsValue, TsValue.TsNumber>(
             method = method,
             { a, b, r ->
-                if (a is TsObject.TsBoolean && b is TsObject.TsBoolean) {
+                if (a is TsValue.TsBoolean && b is TsValue.TsBoolean) {
                     a.value && b.value && r.number == 1.0
                 } else true
             },
             { a, b, r ->
-                if (a is TsObject.TsBoolean && b is TsObject.TsBoolean) {
+                if (a is TsValue.TsBoolean && b is TsValue.TsBoolean) {
                     a.value && !b.value && r.number == 2.0
                 } else true
             },
             { a, b, r ->
-                if (a is TsObject.TsBoolean && b is TsObject.TsBoolean) {
+                if (a is TsValue.TsBoolean && b is TsValue.TsBoolean) {
                     !a.value && b.value && r.number == 3.0
                 } else true
             },
             { a, b, r ->
-                if (a is TsObject.TsBoolean && b is TsObject.TsBoolean) {
+                if (a is TsValue.TsBoolean && b is TsValue.TsBoolean) {
                     !a.value && !b.value && r.number == 4.0
                 } else true
             },
@@ -490,20 +490,20 @@ class And : TsMethodTestRunner() {
     @Test
     fun `test truthyUnknown`() {
         val method = getMethod("And", "truthyUnknown")
-        discoverProperties<TsObject, TsObject, TsObject.TsNumber>(
+        discoverProperties<TsValue, TsValue, TsValue.TsNumber>(
             method = method,
             { a, b, r ->
-                if (a is TsObject.TsBoolean && b is TsObject.TsBoolean) {
+                if (a is TsValue.TsBoolean && b is TsValue.TsBoolean) {
                     a.value && !b.value && r.number == 1.0
                 } else true
             },
             { a, b, r ->
-                if (a is TsObject.TsBoolean && b is TsObject.TsBoolean) {
+                if (a is TsValue.TsBoolean && b is TsValue.TsBoolean) {
                     !a.value && b.value && r.number == 2.0
                 } else true
             },
             { a, b, r ->
-                if (a is TsObject.TsBoolean && b is TsObject.TsBoolean) {
+                if (a is TsValue.TsBoolean && b is TsValue.TsBoolean) {
                     !a.value && !b.value && r.number == 99.0
                 } else true
             },

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Arguments.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Arguments.kt
@@ -3,7 +3,7 @@ package org.usvm.samples
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Disabled
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 import kotlin.test.Test
@@ -20,7 +20,7 @@ class Arguments : TsMethodTestRunner() {
     @Test
     fun testNoArgs() {
         val method = getMethod("SimpleClass", "noArguments")
-        discoverProperties<TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber>(
             method,
             { r -> r.number == 42.0 },
         )
@@ -29,7 +29,7 @@ class Arguments : TsMethodTestRunner() {
     @Test
     fun testSingleArg() {
         val method = getMethod("SimpleClass", "singleArgument")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, r -> a == r },
         )
@@ -38,7 +38,7 @@ class Arguments : TsMethodTestRunner() {
     @Test
     fun testManyArgs() {
         val method = getMethod("SimpleClass", "manyArguments")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, _, _, r -> a.number == 1.0 && r == a },
             { _, b, _, r -> b.number == 2.0 && r == b },
@@ -53,7 +53,7 @@ class Arguments : TsMethodTestRunner() {
     @Disabled
     fun testThisArg() {
         val method = getMethod("SimpleClass", "thisArgument")
-        discoverProperties<TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber>(
             method,
         )
     }

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Call.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Call.kt
@@ -3,7 +3,7 @@ package org.usvm.samples
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Test
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 
@@ -19,7 +19,7 @@ class Call : TsMethodTestRunner() {
     @Test
     fun `test simpleCall`() {
         val method = getMethod("Call", "simpleCall")
-        discoverProperties<TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber>(
             method = method,
             { r -> r.number == 42.0 },
         )
@@ -28,7 +28,7 @@ class Call : TsMethodTestRunner() {
     @Test
     fun `test fib`() {
         val method = getMethod("Call", "fib")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method = method,
             { n, r -> n.number < 0.0 && r.number == -1.0 },
             { n, r -> n.number > 10.0 && r.number == -2.0 },

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Equality.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Equality.kt
@@ -4,7 +4,7 @@ import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 
@@ -20,7 +20,7 @@ class Equality : TsMethodTestRunner() {
     @Disabled("Unsupported array new")
     fun testTruthyTypes() {
         val method = getMethod("Equality", "truthyTypes")
-        discoverProperties<TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber>(
             method,
         )
     }
@@ -28,7 +28,7 @@ class Equality : TsMethodTestRunner() {
     @Test
     fun testEqBoolWithBool() {
         val method = getMethod("Equality", "eqBoolWithBool")
-        discoverProperties<TsObject.TsBoolean, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBoolean, TsValue.TsNumber>(
             method,
             { a, r -> a.value && r.number == 1.0 },
             { a, r -> !a.value && r.number == -1.0 },
@@ -38,7 +38,7 @@ class Equality : TsMethodTestRunner() {
     @Test
     fun testEqNumberWithNumber() {
         val method = getMethod("Equality", "eqNumberWithNumber")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, r -> a.number == 1.1 && r.number == 1.0 },
             { a, r -> a.number.isNaN() && r.number == 2.0 },
@@ -50,7 +50,7 @@ class Equality : TsMethodTestRunner() {
     @Disabled("Unsupported string")
     fun testEqStringWithString() {
         val method = getMethod("Equality", "eqStringWithString")
-        discoverProperties<TsObject.TsString, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsString, TsValue.TsNumber>(
             method,
             { a, r -> a.value == "123" && r.number == 1.0 },
             { a, r -> a.value != "123" && r.number == 2.0 },
@@ -61,7 +61,7 @@ class Equality : TsMethodTestRunner() {
     @Disabled("Unsupported bigint")
     fun testEqBigintWithBigint() {
         val method = getMethod("Equality", "eqBigintWithBigint")
-        discoverProperties<TsObject.TsBigInt, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBigInt, TsValue.TsNumber>(
             method,
             { a, r -> a.value == "42" && r.number == 1.0 },
             { a, r -> a.value == "9999999999999999999999999999999999999" && r.number == 2.0 },
@@ -73,7 +73,7 @@ class Equality : TsMethodTestRunner() {
     @Disabled("Unsupported new construction")
     fun testEqObjectWithObject() {
         val method = getMethod("Equality", "eqObjectWithObject")
-        discoverProperties<TsObject.TsClass, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsClass, TsValue.TsNumber>(
             method,
             { a, r -> r.number == 1.0 },
             invariants = arrayOf(
@@ -86,7 +86,7 @@ class Equality : TsMethodTestRunner() {
     @Test
     fun testEqWithItself() {
         val method = getMethod("Equality", "eqWithItself")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, r -> a.number.isNaN() && r.number == 1.0 },
             { a, r -> !a.number.isNaN() && r.number == 2.0 },

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/InstanceFields.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/InstanceFields.kt
@@ -2,7 +2,7 @@ package org.usvm.samples
 
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 import kotlin.test.Test
@@ -19,17 +19,17 @@ class InstanceFields : TsMethodTestRunner() {
     @Test
     fun testReturnSingleField() {
         val method = getMethod("InstanceFields", "returnSingleField")
-        discoverProperties<TsObject, TsObject>(
+        discoverProperties<TsValue, TsValue>(
             method,
             { x, r ->
                 // Note: this is an attempt to represent `r == x["a"]`
-                if (x !is TsObject.TsClass || r !is TsObject.TsNumber) return@discoverProperties false
+                if (x !is TsValue.TsClass || r !is TsValue.TsNumber) return@discoverProperties false
 
-                val xa = x.properties["a"] as TsObject.TsNumber
+                val xa = x.properties["a"] as TsValue.TsNumber
                 xa.number == r.number || (xa.number.isNaN() && r.number.isNaN())
             },
             { x, r ->
-                (x is TsObject.TsUndefinedObject || x is TsObject.TsNull) && r is TsObject.TsException
+                (x is TsValue.TsUndefined || x is TsValue.TsNull) && r is TsValue.TsException
             }
         )
     }
@@ -37,28 +37,28 @@ class InstanceFields : TsMethodTestRunner() {
     @Test
     fun testDispatchOverField() {
         val method = getMethod("InstanceFields", "dispatchOverField")
-        discoverProperties<TsObject, TsObject>(
+        discoverProperties<TsValue, TsValue>(
             method,
             { x, r ->
-                if (x !is TsObject.TsClass || r !is TsObject.TsNumber) return@discoverProperties false
+                if (x !is TsValue.TsClass || r !is TsValue.TsNumber) return@discoverProperties false
 
-                val xa = x.properties["a"] as TsObject.TsNumber
+                val xa = x.properties["a"] as TsValue.TsNumber
                 xa.number == 1.0 && r.number == 1.0
             },
             { x, r ->
-                if (x !is TsObject.TsClass || r !is TsObject.TsNumber) return@discoverProperties false
+                if (x !is TsValue.TsClass || r !is TsValue.TsNumber) return@discoverProperties false
 
-                val xa = x.properties["a"] as TsObject.TsNumber
+                val xa = x.properties["a"] as TsValue.TsNumber
                 xa.number == 2.0 && r.number == 2.0
             },
             { x, r ->
-                if (x !is TsObject.TsClass || r !is TsObject.TsNumber) return@discoverProperties false
+                if (x !is TsValue.TsClass || r !is TsValue.TsNumber) return@discoverProperties false
 
-                val xa = x.properties["a"] as TsObject.TsNumber
+                val xa = x.properties["a"] as TsValue.TsNumber
                 xa.number != 1.0 && xa.number != 2.0 && r.number == 100.0
             },
             { x, r ->
-                (x is TsObject.TsUndefinedObject || x is TsObject.TsNull) && r is TsObject.TsException
+                (x is TsValue.TsUndefined || x is TsValue.TsNull) && r is TsValue.TsException
             }
         )
     }
@@ -66,17 +66,17 @@ class InstanceFields : TsMethodTestRunner() {
     @Test
     fun testReturnSumOfTwoFields() {
         val method = getMethod("InstanceFields", "returnSumOfTwoFields")
-        discoverProperties<TsObject, TsObject>(
+        discoverProperties<TsValue, TsValue>(
             method,
             { x, r ->
-                if (x !is TsObject.TsClass || r !is TsObject.TsNumber) return@discoverProperties false
+                if (x !is TsValue.TsClass || r !is TsValue.TsNumber) return@discoverProperties false
 
-                val xa = x.properties["a"] as TsObject.TsNumber
-                val xb = x.properties["b"] as TsObject.TsNumber
+                val xa = x.properties["a"] as TsValue.TsNumber
+                val xb = x.properties["b"] as TsValue.TsNumber
                 xa.number + xb.number == r.number
             },
             { x, r ->
-                (x is TsObject.TsUndefinedObject || x is TsObject.TsNull) && r is TsObject.TsException
+                (x is TsValue.TsUndefined || x is TsValue.TsNull) && r is TsValue.TsException
             }
         )
     }

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/InstanceMethods.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/InstanceMethods.kt
@@ -2,7 +2,7 @@ package org.usvm.samples
 
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 import kotlin.test.Test
@@ -19,7 +19,7 @@ class InstanceMethods : TsMethodTestRunner() {
     @Test
     fun testNoArgsInstanceMethod() {
         val method = getMethod("InstanceMethods", "noArguments")
-        discoverProperties<TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber>(
             method,
             { r -> r.number == 42.0 },
         )
@@ -28,7 +28,7 @@ class InstanceMethods : TsMethodTestRunner() {
     @Test
     fun testSingleArgInstanceMethod() {
         val method = getMethod("InstanceMethods", "singleArgument")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, r -> a.number == 1.0 && r.number == 100.0 },
             { a, r -> a.number != 1.0 && r.number == 0.0 },
@@ -38,7 +38,7 @@ class InstanceMethods : TsMethodTestRunner() {
     @Test
     fun testManyArgsInstanceMethod() {
         val method = getMethod("InstanceMethods", "manyArguments")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, _, _, _, r -> a.number == 1.0 && r == a },
             { _, b, _, _, r -> b.number == 2.0 && r == b },

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/MinValue.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/MinValue.kt
@@ -3,7 +3,7 @@ package org.usvm.samples
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Disabled
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 import kotlin.test.Test
@@ -21,7 +21,7 @@ class MinValue : TsMethodTestRunner() {
     @Disabled
     fun testMinValue() {
         val method = getMethod("MinValue", "findMinValue")
-        discoverProperties<TsObject.TsArray, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsArray, TsValue.TsNumber>(
             method,
         )
     }

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Neg.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Neg.kt
@@ -1,11 +1,9 @@
 package org.usvm.samples
 
-import org.jacodb.ets.base.DEFAULT_ARK_CLASS_NAME
-import org.jacodb.ets.model.EtsClassSignature
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Test
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 
@@ -21,7 +19,7 @@ class Neg : TsMethodTestRunner() {
     @Test
     fun `test negateNumber`() {
         val method = getMethod("Neg", "negateNumber")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method = method,
             { x, r -> x.number.isNaN() && r.number.isNaN() },
             { x, r -> x.number == 0.0 && r.number == 0.0 },
@@ -36,7 +34,7 @@ class Neg : TsMethodTestRunner() {
     @Test
     fun `test negateBoolean`() {
         val method = getMethod("Neg", "negateBoolean")
-        discoverProperties<TsObject.TsBoolean, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBoolean, TsValue.TsNumber>(
             method = method,
             { x, r -> x.value && r.number == -1.0 },
             { x, r -> !x.value && r.number == -0.0 },
@@ -46,7 +44,7 @@ class Neg : TsMethodTestRunner() {
     @Test
     fun `test negateUndefined`() {
         val method = getMethod("Neg", "negateUndefined")
-        discoverProperties<TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber>(
             method = method,
             { r -> r.number.isNaN() },
         )

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Null.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Null.kt
@@ -3,7 +3,7 @@ package org.usvm.samples
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.RepeatedTest
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 
@@ -19,10 +19,10 @@ class Null : TsMethodTestRunner() {
     @RepeatedTest(20)
     fun testIsNull() {
         val method = getMethod("Null", "isNull")
-        discoverProperties<TsObject, TsObject.TsNumber>(
+        discoverProperties<TsValue, TsValue.TsNumber>(
             method,
-            { a, r -> a is TsObject.TsNull && r.number == 1.0 },
-            { a, r -> a !is TsObject.TsNull && r.number == 2.0 },
+            { a, r -> a is TsValue.TsNull && r.number == 1.0 },
+            { a, r -> a !is TsValue.TsNull && r.number == 2.0 },
         )
     }
 }

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Or.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Or.kt
@@ -22,7 +22,7 @@ import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.getLocals
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Test
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 import org.usvm.util.isTruthy
@@ -42,7 +42,7 @@ class Or : TsMethodTestRunner() {
     @Test
     fun `test orOfBooleanAndBoolean`() {
         val method = getMethod("Or", "orOfBooleanAndBoolean")
-        discoverProperties<TsObject.TsBoolean, TsObject.TsBoolean, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBoolean, TsValue.TsBoolean, TsValue.TsNumber>(
             method = method,
             { a, b, r -> a.value && b.value && r.number == 1.0 },
             { a, b, r -> a.value && !b.value && r.number == 2.0 },
@@ -136,7 +136,7 @@ class Or : TsMethodTestRunner() {
         locals.clear()
         locals += method.getLocals()
 
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber>(
             method = method,
             { a, b, r -> isTruthy(a) && isTruthy(b) && r.number == 1.0 },
             { a, b, r -> isTruthy(a) && b.number.isNaN() && r.number == 2.0 },

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/StaticMethods.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/StaticMethods.kt
@@ -2,7 +2,7 @@ package org.usvm.samples
 
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 import kotlin.test.Test
@@ -19,7 +19,7 @@ class StaticMethods : TsMethodTestRunner() {
     @Test
     fun testNoArgsStaticMethod() {
         val method = getMethod("StaticMethods", "noArguments")
-        discoverProperties<TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber>(
             method,
             { r -> r.number == 42.0 },
         )
@@ -28,7 +28,7 @@ class StaticMethods : TsMethodTestRunner() {
     @Test
     fun testSingleArgStaticMethod() {
         val method = getMethod("StaticMethods", "singleArgument")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, r -> a.number == 1.0 && r.number == 100.0 },
             { a, r -> a.number != 1.0 && r.number == 0.0 },
@@ -38,7 +38,7 @@ class StaticMethods : TsMethodTestRunner() {
     @Test
     fun testManyArgsStaticMethod() {
         val method = getMethod("StaticMethods", "manyArguments")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, _, _, _, r -> a.number == 1.0 && r == a },
             { _, b, _, _, r -> b.number == 2.0 && r == b },

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/TypeCoercion.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/TypeCoercion.kt
@@ -4,9 +4,10 @@ import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
+import org.usvm.util.isTruthy
 
 class TypeCoercion : TsMethodTestRunner() {
 
@@ -17,10 +18,13 @@ class TypeCoercion : TsMethodTestRunner() {
         EtsScene(listOf(file))
     }
 
+    private val TsValue.TsBoolean.number: Double
+        get() = if (value) 1.0 else 0.0
+
     @Test
     fun testArgWithConst() {
         val method = getMethod("TypeCoercion", "argWithConst")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, r -> a.number == 1.0 && r.number == 1.0 },
             { a, r -> a.number != 1.0 && r.number == 0.0 },
@@ -30,7 +34,7 @@ class TypeCoercion : TsMethodTestRunner() {
     @Test
     fun testDualBoolean() {
         val method = getMethod("TypeCoercion", "dualBoolean")
-        discoverProperties<TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, r -> a.number == 0.0 && r.number == -1.0 },
             { a, r -> a.number == 1.0 && r.number == 2.0 },
@@ -45,7 +49,7 @@ class TypeCoercion : TsMethodTestRunner() {
     @Disabled("Unsupported string")
     fun testDualBooleanWithoutTypes() {
         val method = getMethod("TypeCoercion", "dualBooleanWithoutTypes")
-        discoverProperties<TsObject.TsUnknown, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsUnknown, TsValue.TsNumber>(
             method,
         )
     }
@@ -53,7 +57,7 @@ class TypeCoercion : TsMethodTestRunner() {
     @Test
     fun testArgWithArg() {
         val method = getMethod("TypeCoercion", "argWithArg")
-        discoverProperties<TsObject.TsBoolean, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsBoolean, TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, b, r -> (a.number + b.number == 10.0) && r.number == 1.0 },
             { a, b, r -> (a.number + b.number != 10.0) && r.number == 0.0 },
@@ -63,10 +67,10 @@ class TypeCoercion : TsMethodTestRunner() {
     @Test
     fun testUnreachableByType() {
         val method = getMethod("TypeCoercion", "unreachableByType")
-        discoverProperties<TsObject.TsNumber, TsObject.TsBoolean, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsBoolean, TsValue.TsNumber>(
             method,
             { a, b, r -> a.number != b.number && r.number == 2.0 },
-            { a, b, r -> (a.number == b.number) && !(a.truthyValue && !b.value) && r.number == 1.0 },
+            { a, b, r -> (a.number == b.number) && !(isTruthy(a) && !b.value) && r.number == 1.0 },
             invariants = arrayOf(
                 { _, _, r -> r.number != 0.0 },
             )
@@ -77,10 +81,10 @@ class TypeCoercion : TsMethodTestRunner() {
     @Disabled("Wrong IR, incorrect handling of NaN value")
     fun testTransitiveCoercion() {
         val method = getMethod("TypeCoercion", "transitiveCoercion")
-        discoverProperties<TsObject.TsNumber, TsObject.TsBoolean, TsObject.TsNumber, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsNumber, TsValue.TsBoolean, TsValue.TsNumber, TsValue.TsNumber>(
             method,
             { a, b, c, r -> a.number == b.number && b.number == c.number && r.number == 1.0 },
-            { a, b, c, r -> a.number == b.number && (b.number != c.number || !c.truthyValue) && r.number == 2.0 },
+            { a, b, c, r -> a.number == b.number && (b.number != c.number || !isTruthy(c)) && r.number == 2.0 },
             { a, b, _, r -> a.number != b.number && r.number == 3.0 },
         )
     }
@@ -88,7 +92,7 @@ class TypeCoercion : TsMethodTestRunner() {
     @Test
     fun testTransitiveCoercionNoTypes() {
         val method = getMethod("TypeCoercion", "transitiveCoercionNoTypes")
-        discoverProperties<TsObject.TsUnknown, TsObject.TsUnknown, TsObject.TsUnknown, TsObject.TsNumber>(
+        discoverProperties<TsValue.TsUnknown, TsValue.TsUnknown, TsValue.TsUnknown, TsValue.TsNumber>(
             method,
             // Too complicated to write property matchers, examine run log to verify the test.
         )

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Undefined.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Undefined.kt
@@ -3,7 +3,7 @@ package org.usvm.samples
 import org.jacodb.ets.model.EtsScene
 import org.jacodb.ets.utils.loadEtsFileAutoConvert
 import org.junit.jupiter.api.Test
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 import org.usvm.util.TsMethodTestRunner
 import org.usvm.util.getResourcePath
 
@@ -19,10 +19,10 @@ class Undefined : TsMethodTestRunner() {
     @Test
     fun `test isUndefined`() {
         val method = getMethod("Undefined", "isUndefined")
-        discoverProperties<TsObject, TsObject.TsNumber>(
+        discoverProperties<TsValue, TsValue.TsNumber>(
             method = method,
-            { a, r -> a is TsObject.TsUndefinedObject && r.number == 1.0 },
-            { a, r -> a !is TsObject.TsUndefinedObject && r.number == 2.0 },
+            { a, r -> a is TsValue.TsUndefined && r.number == 1.0 },
+            { a, r -> a !is TsValue.TsUndefined && r.number == 2.0 },
         )
     }
 }

--- a/usvm-ts/src/test/kotlin/org/usvm/util/Truthy.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/util/Truthy.kt
@@ -1,19 +1,19 @@
 package org.usvm.util
 
-import org.usvm.api.TsObject
+import org.usvm.api.TsValue
 
 fun isTruthy(x: Double): Boolean {
     return x != 0.0 && !x.isNaN()
 }
 
-fun isTruthy(x: TsObject.TsNumber): Boolean {
+fun isTruthy(x: TsValue.TsNumber): Boolean {
     return isTruthy(x.number)
 }
 
-fun isTruthy(x: TsObject.TsClass): Boolean {
+fun isTruthy(x: TsValue.TsClass): Boolean {
     return true
 }
 
-fun isTruthy(x: TsObject.TsObject): Boolean {
+fun isTruthy(x: TsValue.TsObject): Boolean {
     return x.addr != 0
 }

--- a/usvm-ts/src/test/kotlin/org/usvm/util/TsMethodTestRunner.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/util/TsMethodTestRunner.kt
@@ -19,8 +19,8 @@ import org.usvm.PathSelectionStrategy
 import org.usvm.UMachineOptions
 import org.usvm.api.NoCoverage
 import org.usvm.api.TsMethodCoverage
-import org.usvm.api.TsObject
 import org.usvm.api.TsTest
+import org.usvm.api.TsValue
 import org.usvm.machine.TsMachine
 import org.usvm.test.util.TestRunner
 import org.usvm.test.util.checkers.ignoreNumberOfAnalysisResults
@@ -43,7 +43,7 @@ abstract class TsMethodTestRunner : TestRunner<TsTest, EtsMethod, EtsType?, TsMe
 
     protected val doNotCheckCoverage: CoverageChecker = { _ -> true }
 
-    protected inline fun <reified R : TsObject> discoverProperties(
+    protected inline fun <reified R : TsValue> discoverProperties(
         method: EtsMethod,
         vararg analysisResultMatchers: (R) -> Boolean,
         invariants: Array<(R) -> Boolean> = emptyArray(),
@@ -61,7 +61,7 @@ abstract class TsMethodTestRunner : TestRunner<TsTest, EtsMethod, EtsType?, TsMe
         )
     }
 
-    protected inline fun <reified T : TsObject, reified R : TsObject> discoverProperties(
+    protected inline fun <reified T : TsValue, reified R : TsValue> discoverProperties(
         method: EtsMethod,
         vararg analysisResultMatchers: (T, R) -> Boolean,
         invariants: Array<(T, R) -> Boolean> = emptyArray(),
@@ -79,7 +79,7 @@ abstract class TsMethodTestRunner : TestRunner<TsTest, EtsMethod, EtsType?, TsMe
         )
     }
 
-    protected inline fun <reified T1 : TsObject, reified T2 : TsObject, reified R : TsObject> discoverProperties(
+    protected inline fun <reified T1 : TsValue, reified T2 : TsValue, reified R : TsValue> discoverProperties(
         method: EtsMethod,
         vararg analysisResultMatchers: (T1, T2, R) -> Boolean,
         invariants: Array<(T1, T2, R) -> Boolean> = emptyArray(),
@@ -99,7 +99,7 @@ abstract class TsMethodTestRunner : TestRunner<TsTest, EtsMethod, EtsType?, TsMe
         )
     }
 
-    protected inline fun <reified T1 : TsObject, reified T2 : TsObject, reified T3 : TsObject, reified R : TsObject> discoverProperties(
+    protected inline fun <reified T1 : TsValue, reified T2 : TsValue, reified T3 : TsValue, reified R : TsValue> discoverProperties(
         method: EtsMethod,
         vararg analysisResultMatchers: (T1, T2, T3, R) -> Boolean,
         invariants: Array<(T1, T2, T3, R) -> Boolean> = emptyArray(),
@@ -122,7 +122,7 @@ abstract class TsMethodTestRunner : TestRunner<TsTest, EtsMethod, EtsType?, TsMe
         )
     }
 
-    protected inline fun <reified T1 : TsObject, reified T2 : TsObject, reified T3 : TsObject, reified T4 : TsObject, reified R : TsObject> discoverProperties(
+    protected inline fun <reified T1 : TsValue, reified T2 : TsValue, reified T3 : TsValue, reified T4 : TsValue, reified R : TsValue> discoverProperties(
         method: EtsMethod,
         vararg analysisResultMatchers: (T1, T2, T3, T4, R) -> Boolean,
         invariants: Array<(T1, T2, T3, T4, R) -> Boolean> = emptyArray(),
@@ -164,27 +164,27 @@ abstract class TsMethodTestRunner : TestRunner<TsTest, EtsMethod, EtsType?, TsMe
         */
         val klass = if (it is KClass<*>) it else it::class
         when (klass) {
-            TsObject::class -> EtsAnyType
-            TsObject.TsAny::class -> EtsAnyType
-            TsObject.TsArray::class -> TODO()
-            TsObject.TsBoolean::class -> EtsBooleanType
-            TsObject.TsClass::class -> {
+            TsValue::class -> EtsAnyType
+            TsValue.TsAny::class -> EtsAnyType
+            TsValue.TsArray::class -> TODO()
+            TsValue.TsBoolean::class -> EtsBooleanType
+            TsValue.TsClass::class -> {
                 // TODO incorrect
                 val signature = EtsClassSignature(it.toString(), EtsFileSignature.DEFAULT)
                 EtsClassType(signature)
             }
 
-            TsObject.TsString::class -> EtsStringType
-            TsObject.TsNumber::class -> EtsNumberType
-            TsObject.TsNumber.Double::class -> EtsNumberType
-            TsObject.TsNumber.Integer::class -> EtsNumberType
-            TsObject.TsUndefinedObject::class -> EtsUndefinedType
+            TsValue.TsString::class -> EtsStringType
+            TsValue.TsNumber::class -> EtsNumberType
+            TsValue.TsNumber.TsDouble::class -> EtsNumberType
+            TsValue.TsNumber.TsInteger::class -> EtsNumberType
+            TsValue.TsUndefined::class -> EtsUndefinedType
             // TODO: EtsUnknownType is mock up here. Correct implementation required.
-            TsObject.TsObject::class -> EtsUnknownType
+            TsValue.TsObject::class -> EtsUnknownType
             // For untyped tests, not to limit objects serialized from models after type coercion.
-            TsObject.TsUnknown::class -> EtsUnknownType
-            TsObject.TsNull::class -> EtsNullType
-            TsObject.TsException::class -> {
+            TsValue.TsUnknown::class -> EtsUnknownType
+            TsValue.TsNull::class -> EtsNullType
+            TsValue.TsException::class -> {
                 // TODO incorrect
                 val signature = EtsClassSignature("Exception", EtsFileSignature.DEFAULT)
                 EtsClassType(signature)

--- a/usvm-ts/src/test/resources/logback.xml
+++ b/usvm-ts/src/test/resources/logback.xml
@@ -6,6 +6,6 @@
     </appender>
 
     <root level="info">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/usvm-ts/src/test/resources/samples/Equality.ts
+++ b/usvm-ts/src/test/resources/samples/Equality.ts
@@ -39,7 +39,7 @@ class Equality {
     }
 
     eqObjectWithObject(a: object): number {
-        if (a == { b: 0}) {
+        if (a == {b: 0}) {
             return -1
         }
 


### PR DESCRIPTION
This PR renames `TsObject` to `TsValue` to better match the intention and to avoid `TsObject.TsObject`.