### PR TITLE
Add mkNumericExpr

### DIFF
--- a/usvm-ts/src/main/kotlin/org/usvm/machine/expr/TsExprResolver.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/machine/expr/TsExprResolver.kt
@@ -424,6 +424,13 @@ class TsExprResolver(
     }
 
     override fun visit(expr: EtsStaticCallExpr): UExpr<out USort>? {
+        if (expr.method.name == "Number" && expr.method.enclosingClass.name == "") {
+            check(expr.args.size == 1) { "Number constructor should have exactly one argument" }
+            return resolveAfterResolved(expr.args.single()) {
+                ctx.mkNumericExpr(it, scope)
+            }
+        }
+
         return resolveInvoke(
             method = expr.method,
             instance = null,

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/Numeric.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/Numeric.kt
@@ -1,0 +1,231 @@
+package org.usvm.samples
+
+import org.jacodb.ets.model.EtsScene
+import org.jacodb.ets.utils.loadEtsFileAutoConvert
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.usvm.api.TsValue
+import org.usvm.util.TsMethodTestRunner
+import org.usvm.util.getResourcePath
+
+class Numeric : TsMethodTestRunner() {
+
+    override val scene: EtsScene = run {
+        val name = "Numeric.ts"
+        val path = getResourcePath("/samples/$name")
+        val file = loadEtsFileAutoConvert(path)
+        EtsScene(listOf(file))
+    }
+
+    @Test
+    fun `test numberToNumber`() {
+        val method = getMethod("Numeric", "numberToNumber")
+        // ```ts
+        // if (x != x) return Number(x) // NaN
+        // if (x == 0) return Number(x) // 0
+        // if (x > 0) return Number(x) // x (>0)
+        // if (x < 0) return Number(x) // x (<0)
+        // ```
+        discoverProperties<TsValue.TsNumber, TsValue.TsNumber>(
+            method = method,
+            { x, r -> x.number.isNaN() && r.number.isNaN() },
+            { x, r -> x.number == 0.0 && r.number == 0.0 },
+            { x, r -> x.number > 0 && r.number == x.number },
+            { x, r -> x.number < 0 && r.number == x.number },
+        )
+    }
+
+    @Test
+    fun `test boolToNumber`() {
+        val method = getMethod("Numeric", "boolToNumber")
+        // ```ts
+        // if (x) return Number(x) // 1
+        // if (!x) return Number(x) // 0
+        // ```
+        discoverProperties<TsValue.TsBoolean, TsValue.TsNumber>(
+            method = method,
+            { x, r -> x.value && r.number == 1.0 },
+            { x, r -> !x.value && r.number == 0.0 },
+        )
+    }
+
+    @Test
+    fun `test undefinedToNumber`() {
+        val method = getMethod("Numeric", "undefinedToNumber")
+        // ```ts
+        // return Number(undefined) // NaN
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number.isNaN() },
+        )
+    }
+
+    @Test
+    fun `test nullToNumber`() {
+        val method = getMethod("Numeric", "nullToNumber")
+        // ```ts
+        // return Number(null) // 0
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 0.0 },
+        )
+    }
+
+    @Disabled("Strings are not supported")
+    @Test
+    fun `test emptyStringToNumber`() {
+        val method = getMethod("Numeric", "emptyStringToNumber")
+        // ```ts
+        // return Number("") // 0
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 0.0 },
+        )
+    }
+
+    @Disabled("Strings are not supported")
+    @Test
+    fun `test numberStringToNumber`() {
+        val method = getMethod("Numeric", "numberStringToNumber")
+        // ```ts
+        // return Number("42") // 42
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 42.0 },
+        )
+    }
+
+    @Disabled("Strings are not supported")
+    @Test
+    fun `test stringToNumber`() {
+        val method = getMethod("Numeric", "stringToNumber")
+        // ```ts
+        // return Number("hello") // NaN
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number.isNaN() },
+        )
+    }
+
+    @Disabled("Unsupported sort: Address")
+    @Test
+    fun `test emptyArrayToNumber`() {
+        val method = getMethod("Numeric", "emptyArrayToNumber")
+        // ```ts
+        // return Number([]) // 0
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 0.0 },
+        )
+    }
+
+    @Disabled("Unsupported sort: Address")
+    @Test
+    fun `test singleNumberArrayToNumber`() {
+        val method = getMethod("Numeric", "singleNumberArrayToNumber")
+        // ```ts
+        // return Number([42]) // 42
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 42.0 },
+        )
+    }
+
+    @Disabled("Unsupported sort: Address")
+    @Test
+    fun `test singleUndefinedArrayToNumber`() {
+        val method = getMethod("Numeric", "singleUndefinedArrayToNumber")
+        // ```ts
+        // return Number([undefined]) // 0
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 0.0 },
+        )
+    }
+
+    @Disabled("Could not resolve unique constructor of anonymous class")
+    @Test
+    fun `test singleObjectArrayToNumber`() {
+        val method = getMethod("Numeric", "singleObjectArrayToNumber")
+        // ```ts
+        // return Number([{}]) // NaN
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number.isNaN() },
+        )
+    }
+
+    @Disabled("Could not resolve unique FortyTwo::constructor")
+    @Test
+    fun `test singleCustomFortyTwoObjectArrayToNumber`() {
+        val method = getMethod("Numeric", "singleCustomFortyTwoObjectArrayToNumber")
+        // ```ts
+        // return Number([new FortyTwo()]) // 42
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 42.0 },
+        )
+    }
+
+    @Disabled("Unsupported sort: Address")
+    @Test
+    fun `test multipleElementArrayToNumber`() {
+        val method = getMethod("Numeric", "multipleElementArrayToNumber")
+        // ```ts
+        // return Number([5, 100]) // NaN
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number.isNaN() },
+        )
+    }
+
+    @Disabled("Could not resolve unique constructor of anonymous class")
+    @Test
+    fun `test emptyObjectToNumber`() {
+        val method = getMethod("Numeric", "emptyObjectToNumber")
+        // ```ts
+        // return Number({}) // NaN
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number.isNaN() },
+        )
+    }
+
+    @Disabled("Could not resolve unique constructor of anonymous class")
+    @Test
+    fun `test objectToNumber`() {
+        val method = getMethod("Numeric", "objectToNumber")
+        // ```ts
+        // return Number({a: 42}) // NaN
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number.isNaN() },
+        )
+    }
+
+    @Disabled("Could not resolve unique FortyTwo::constructor")
+    @Test
+    fun `test customFortyTwoObjectToNumber`() {
+        val method = getMethod("Numeric", "customFortyTwoObjectToNumber")
+        // ```ts
+        // return Number(new FortyTwo()) // 42
+        // ```
+        discoverProperties<TsValue.TsNumber>(
+            method = method,
+            { r -> r.number == 42.0 },
+        )
+    }
+}

--- a/usvm-ts/src/test/resources/samples/Numeric.ts
+++ b/usvm-ts/src/test/resources/samples/Numeric.ts
@@ -1,0 +1,91 @@
+class Numeric {
+    numberToNumber(x: number): number {
+        if (x != x) return Number(x) // NaN
+        if (x == 0) return Number(x) // 0
+        if (x > 0) return Number(x) // x (>0)
+        if (x < 0) return Number(x) // x (<0)
+        // unreachable
+    }
+
+    boolToNumber(x: boolean): number {
+        if (x) return Number(x) // 1
+        if (!x) return Number(x) // 0
+        // unreachable
+    }
+
+    undefinedToNumber(): number {
+        let x = undefined
+        return Number(x) // NaN
+    }
+
+    nullToNumber(): number {
+        let x = null
+        return Number(x) // 0
+    }
+
+    emptyStringToNumber(): number {
+        let x = ""
+        return Number(x) // 0
+    }
+
+    numberStringToNumber(): number {
+        let x = "42"
+        return Number(x) // 42
+    }
+
+    stringToNumber(): number {
+        let x = "hello"
+        return Number(x) // NaN
+    }
+
+    emptyArrayToNumber(): number {
+        let x = []
+        return Number(x) // 0
+    }
+
+    singleNumberArrayToNumber(): number {
+        let x = [42]
+        return Number(x) // 42
+    }
+
+    singleUndefinedArrayToNumber(): number {
+        let x = [undefined]
+        return Number(x) // 0
+    }
+
+    singleObjectArrayToNumber(): number {
+        let x = [{}]
+        return Number(x) // NaN
+    }
+
+    singleCustomFortyTwoObjectArrayToNumber(): number {
+        let x = [new FortyTwo()]
+        return Number(x) // 42
+    }
+
+    multipleElementArrayToNumber(): number {
+        let x = [5, 100]
+        return Number(x) // NaN
+    }
+
+    emptyObjectToNumber(): number {
+        let x = {}
+        return Number(x) // NaN
+    }
+
+    objectToNumber(): number {
+        let x = {a: 42}
+        return Number(x) // NaN
+    }
+
+    customFortyTwoObjectToNumber(): number {
+        let x = new FortyTwo()
+        return Number(x) // 42
+    }
+}
+
+class FortyTwo {
+    toString() {
+        return "42"
+    }
+}


### PR DESCRIPTION
This PR adds `mkNumericExpr` to mimic [`ToNumber` method](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tonumber) from ECMA spec.

It is yet unclear what to do with arbitrary objects, since the process of converting them to numbers relies on `toString`, which is then parsed to a number.

And currently this PR does not yet handle fake objects, but some simple cases (wrapped numbers/booleans) _could_ be handled.

- [ ] Handle fake objects.
- [x] Add tests.
- [ ] Enable tests with arrays when https://github.com/UnitTestBot/usvm/pull/256 is merged.