### PR TITLE
Add call/field resolver, disable AA type inference

### DIFF
--- a/usvm-ts/src/main/kotlin/org/usvm/util/Utils.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/util/Utils.kt
@@ -2,8 +2,6 @@ package org.usvm.util
 
 import io.ksmt.sort.KFp64Sort
 import org.jacodb.ets.base.EtsType
-import org.jacodb.ets.model.EtsFieldSignature
-import org.jacodb.ets.model.EtsScene
 import org.usvm.UBoolSort
 import org.usvm.UExpr
 import org.usvm.UHeapRef
@@ -14,12 +12,6 @@ import org.usvm.machine.state.TsState
 // Built-in KContext.bvToBool has identical implementation.
 fun TsContext.boolToFp(expr: UExpr<UBoolSort>): UExpr<KFp64Sort> =
     mkIte(expr, mkFp64(1.0), mkFp64(0.0))
-
-// TODO probably this should be written differently
-fun EtsScene.fieldLookUp(field: EtsFieldSignature) = projectAndSdkClasses
-    .first { it.signature == field.enclosingClass }
-    .fields
-    .single { it.name == field.name }
 
 fun TsState.throwExceptionWithoutStackFrameDrop(address: UHeapRef, type: EtsType) {
     methodResult = TsMethodResult.TsException(address, type)

--- a/usvm-ts/src/test/kotlin/org/usvm/util/TsMethodTestRunner.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/util/TsMethodTestRunner.kt
@@ -38,7 +38,7 @@ abstract class TsMethodTestRunner : TestRunner<TsTest, EtsMethod, EtsType?, TsMe
 
     protected fun loadSampleScene(
         className: String,
-        useArkAnalyzerTypeInference: Boolean = true,
+        useArkAnalyzerTypeInference: Boolean = false,
     ): EtsScene {
         val name = "$className.ts"
         val path = getResourcePath("/samples/$name")


### PR DESCRIPTION
This PR adds simple (yet better than it was before) call/field resolver.

Also, we decided to turn off ArkAnalyzer's type inference in order to test and evaluate our SE engine more carefully in situation when most of the value have unknown types. Known types are beneficial, but currently we might unconsciously rely on their presence too much. Fixing the issues with call/field resolver in this PR allowed to pass the test suite we already have. If necessary, AA's type inference can be enable via an option during the scene loading.