### PR TITLE
Add live variables analysis before type inference

### DIFF
--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/AccessPath.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/AccessPath.kt
@@ -1,6 +1,7 @@
 package org.usvm.dataflow.ts.infer
 
 import org.jacodb.ets.base.EtsArrayAccess
+import org.jacodb.ets.base.EtsAwaitExpr
 import org.jacodb.ets.base.EtsCastExpr
 import org.jacodb.ets.base.EtsConstant
 import org.jacodb.ets.base.EtsEntity
@@ -128,6 +129,8 @@ fun EtsEntity.toPathOrNull(): AccessPath? = when (this) {
     }
 
     is EtsCastExpr -> arg.toPathOrNull()
+
+    is EtsAwaitExpr -> arg.toPathOrNull()
 
     else -> null
 }

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -179,17 +179,17 @@ class StmtAliasInfoImpl(
         if (stmt !is EtsAssignStmt) {
             return this
         }
-        when (val rhv = stmt.rhv) {
+        return when (val rhv = stmt.rhv) {
             is EtsParameterRef -> {
                 val alloc = method.allocationMap[Allocation.Arg(rhv.index)]
                     ?: error("Unknown parameter ref")
-                return assign(stmt.lhv.toPath(), alloc)
+                assign(stmt.lhv.toPath(), alloc)
             }
 
             is EtsThis -> {
                 val alloc = method.allocationMap[Allocation.This]
                     ?: error("Uninitialized this")
-                return assign(stmt.lhv.toPath(), alloc)
+                assign(stmt.lhv.toPath(), alloc)
             }
 
             is EtsInstanceFieldRef, is EtsStaticFieldRef -> {
@@ -198,39 +198,38 @@ class StmtAliasInfoImpl(
                 if (alloc == NOT_PROCESSED) {
                     val fieldAlloc = method.allocationMap[Allocation.Imm(stmt)]
                         ?: error("Unknown allocation")
-
-                    return this
+                    this
                         .assign(rhv.toPath(), fieldAlloc)
                         .assign(stmt.lhv.toPath(), fieldAlloc)
                 } else {
-                    return assign(stmt.lhv.toPath(), alloc)
+                    assign(stmt.lhv.toPath(), alloc)
                 }
             }
 
             is EtsLocal -> {
-                return assign(stmt.lhv.toPath(), rhv.toPath())
+                assign(stmt.lhv.toPath(), rhv.toPath())
             }
 
             is EtsCastExpr -> {
-                return assign(stmt.lhv.toPath(), rhv.arg.toPath())
+                assign(stmt.lhv.toPath(), rhv.arg.toPath())
             }
 
             is EtsConstant, is EtsUnaryExpr, is EtsBinaryExpr, is EtsArrayAccess, is EtsInstanceOfExpr -> {
                 val imm = method.allocationMap[Allocation.Expr(stmt)]
                     ?: error("Unknown constant")
-                return assign(stmt.lhv.toPath(), imm)
+                assign(stmt.lhv.toPath(), imm)
             }
 
             is EtsCallExpr -> {
                 val callResult = method.allocationMap[Allocation.CallResult(stmt)]
                     ?: error("Unknown call")
-                return assign(stmt.lhv.toPath(), callResult)
+                assign(stmt.lhv.toPath(), callResult)
             }
 
             is EtsNewExpr, is EtsNewArrayExpr -> {
                 val new = method.allocationMap[Allocation.New(stmt)]
                     ?: error("Unknown new")
-                return assign(stmt.lhv.toPath(), new)
+                assign(stmt.lhv.toPath(), new)
             }
 
             else -> {

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -202,12 +202,11 @@ class StmtAliasInfoImpl(
                 if (alloc == NOT_PROCESSED) {
                     val fieldAlloc = method.allocationMap[Allocation.Imm(stmt)]
                         ?: error("Unknown allocation in stmt: $stmt")
-                    this
+                    return this
                         .assign(rhv.toPath(), fieldAlloc)
                         .assign(stmt.lhv.toPath(), fieldAlloc)
-                } else {
-                    assign(stmt.lhv.toPath(), alloc)
                 }
+                assign(stmt.lhv.toPath(), alloc)
             }
 
             is EtsLocal -> {

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -459,6 +459,7 @@ class MethodAliasInfoImpl(
                         }
 
                         is EtsCastExpr -> {}
+
                         is EtsConstant, is EtsUnaryExpr, is EtsBinaryExpr, is EtsArrayAccess, is EtsInstanceOfExpr -> {
                             newAllocation(Allocation.Expr(stmt))
                         }

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -475,7 +475,7 @@ class MethodAliasInfoImpl(
         postOrderDfs(root)
         order.reverse()
 
-        fun computePreAliases(stmt: EtsStmt): StmtAliasInfoImpl {
+        fun computePreAliases(stmt: EtsStmt): StmtAliasInfo {
             if (stmt in preAliases) return preAliases.getValue(stmt)
 
             val merged = preds[stmt]
@@ -491,13 +491,13 @@ class MethodAliasInfoImpl(
             return merged
         }
 
-        val aliases = Array<StmtAliasInfoImpl?>(method.cfg.stmts.size) { null }
+        val aliases = Array<StmtAliasInfo?>(method.cfg.stmts.size) { null }
         for (stmt in order) {
             aliases[stmt.location.index] = computePreAliases(stmt)
         }
 
         assert(!aliases.contains(null))
-        return (aliases as Array<StmtAliasInfoImpl>).toList()
+        return (aliases as Array<StmtAliasInfo>).toList()
     }
 }
 

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -334,7 +334,7 @@ class MethodAliasInfoImpl(
         data class New(val stmt: EtsStmt) : Allocation
         data class CallResult(val stmt: EtsStmt) : Allocation
         data class Arg(val index: Int) : Allocation
-        object This : Allocation
+        data object This : Allocation
         data class Imm(val stmt: EtsStmt) : Allocation
         data class Expr(val stmt: EtsStmt) : Allocation
         data class Static(val clazz: EtsClassSignature) : Allocation

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -386,7 +386,8 @@ class MethodAliasInfoImpl(
                 newAllocation(Allocation.Static(base.clazz))
             }
 
-            is AccessPathBase.Const -> { /* TODO ?? may be some non-trivial */
+            is AccessPathBase.Const -> {
+                // TODO: non-trivial
             }
         }
     }

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -1,5 +1,6 @@
 package org.usvm.dataflow.ts.infer
 
+import mu.KotlinLogging
 import org.jacodb.ets.base.EtsArrayAccess
 import org.jacodb.ets.base.EtsAssignStmt
 import org.jacodb.ets.base.EtsBinaryExpr
@@ -22,6 +23,8 @@ import org.jacodb.ets.base.EtsUnaryExpr
 import org.jacodb.ets.model.EtsClassSignature
 import org.jacodb.ets.model.EtsMethod
 import org.usvm.dataflow.ts.infer.MethodAliasInfoImpl.Allocation
+
+private val logger = KotlinLogging.logger {}
 
 interface StmtAliasInfo {
     fun getAliases(path: AccessPath): Set<AccessPath>
@@ -234,7 +237,8 @@ class StmtAliasInfoImpl(
             }
 
             else -> {
-                error("Unprocessable rhs in stmt: $stmt")
+                logger.warn { "Unprocessable rhs in stmt: $stmt" }
+                this
             }
         }
     }

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -21,6 +21,7 @@ import org.jacodb.ets.base.EtsThis
 import org.jacodb.ets.base.EtsUnaryExpr
 import org.jacodb.ets.model.EtsClassSignature
 import org.jacodb.ets.model.EtsMethod
+import org.usvm.dataflow.ts.infer.MethodAliasInfoImpl.Allocation
 import kotlin.collections.ArrayDeque
 
 interface StmtAliasInfo {
@@ -180,12 +181,12 @@ class StmtAliasInfoImpl(
         }
         when (val rhv = stmt.rhv) {
             is EtsParameterRef -> {
-                val alloc = method.allocationMap[MethodAliasInfoImpl.Allocation.Arg(rhv.index)]
+                val alloc = method.allocationMap[Allocation.Arg(rhv.index)]
                     ?: error("Unknown parameter ref")
                 return assign(stmt.lhv.toPath(), alloc)
             }
             is EtsThis -> {
-                val alloc = method.allocationMap[MethodAliasInfoImpl.Allocation.This]
+                val alloc = method.allocationMap[Allocation.This]
                     ?: error("Uninitialized this")
                 return assign(stmt.lhv.toPath(), alloc)
             }
@@ -193,7 +194,7 @@ class StmtAliasInfoImpl(
                 val (rhvNodes, _) = trace(rhv.toPath())
                 val alloc = rhvNodes.last()
                 if (alloc == NOT_PROCESSED) {
-                    val fieldAlloc = method.allocationMap[MethodAliasInfoImpl.Allocation.Imm(stmt)]
+                    val fieldAlloc = method.allocationMap[Allocation.Imm(stmt)]
                         ?: error("Unknown allocation")
 
                     return this
@@ -210,17 +211,17 @@ class StmtAliasInfoImpl(
                 return assign(stmt.lhv.toPath(), rhv.arg.toPath())
             }
             is EtsConstant, is EtsUnaryExpr, is EtsBinaryExpr, is EtsArrayAccess, is EtsInstanceOfExpr -> {
-                val imm = method.allocationMap[MethodAliasInfoImpl.Allocation.Expr(stmt)]
+                val imm = method.allocationMap[Allocation.Expr(stmt)]
                     ?: error("Unknown constant")
                 return assign(stmt.lhv.toPath(), imm)
             }
             is EtsCallExpr -> {
-                val callResult = method.allocationMap[MethodAliasInfoImpl.Allocation.CallResult(stmt)]
+                val callResult = method.allocationMap[Allocation.CallResult(stmt)]
                     ?: error("Unknown call")
                 return assign(stmt.lhv.toPath(), callResult)
             }
             is EtsNewExpr, is EtsNewArrayExpr -> {
-                val new = method.allocationMap[MethodAliasInfoImpl.Allocation.New(stmt)]
+                val new = method.allocationMap[Allocation.New(stmt)]
                     ?: error("Unknown new")
                 return assign(stmt.lhv.toPath(), new)
             }

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -154,12 +154,10 @@ class StmtAliasInfoImpl(
                 s == str
             }
             if (edgeIndex == -1) {
-                updated.allocToFields[from] = allocToFields[from].toMutableList().apply {
-                    add(wrap(str, newAlloc))
-                }.toULongArray()
+                updated.allocToFields[from] = allocToFields[from] + wrap(str, newAlloc)
             } else {
-                updated.allocToFields[from] = allocToFields[from].copyOf().apply {
-                    set(edgeIndex, wrap(str, newAlloc))
+                updated.allocToFields[from] = allocToFields[from].copyOf().also {
+                    it[edgeIndex] = wrap(str, newAlloc)
                 }
             }
 

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/Alias.kt
@@ -37,13 +37,12 @@ class StmtAliasInfoImpl(
     val allocToFields: Array<ULongArray>,
     val method: MethodAliasInfoImpl,
 ) : StmtAliasInfo {
-    internal companion object {
+    companion object {
         internal const val NOT_PROCESSED = -1
         internal const val MULTIPLE_EDGE = -2
-
         internal const val ELEMENT_ACCESSOR = -3
 
-        internal fun merge(first: Int, second: Int): Int = when {
+        private fun merge(first: Int, second: Int): Int = when {
             first == NOT_PROCESSED -> second
             second == NOT_PROCESSED -> first
             first == MULTIPLE_EDGE -> MULTIPLE_EDGE
@@ -52,11 +51,11 @@ class StmtAliasInfoImpl(
             else -> MULTIPLE_EDGE
         }
 
-        internal fun wrap(string: Int, alloc: Int): ULong {
+        private fun wrap(string: Int, alloc: Int): ULong {
             return (string.toULong() shl Int.SIZE_BITS) or alloc.toULong()
         }
 
-        internal fun unwrap(edge: ULong): Pair<Int, Int> {
+        private fun unwrap(edge: ULong): Pair<Int, Int> {
             val string = (edge shr Int.SIZE_BITS).toInt()
             val allocation = (edge and UInt.MAX_VALUE.toULong()).toInt()
             return Pair(string, allocation)

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/ForwardAnalyzer.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/ForwardAnalyzer.kt
@@ -14,9 +14,18 @@ class ForwardAnalyzer(
     methodInitialTypes: Map<EtsMethod, Map<AccessPathBase, EtsTypeFact>>,
     typeInfo: Map<EtsType, EtsTypeFact>,
     doAddKnownTypes: Boolean = true,
+    doAliasAnalysis: Boolean = true,
+    val doLiveVariablesAnalysis: Boolean = true,
 ) : Analyzer<ForwardTypeDomainFact, AnalyzerEvent, EtsMethod, EtsStmt> {
 
-    override val flowFunctions = ForwardFlowFunctions(graph, methodInitialTypes, typeInfo, doAddKnownTypes)
+    override val flowFunctions = ForwardFlowFunctions(
+        graph = graph,
+        methodInitialTypes = methodInitialTypes,
+        typeInfo = typeInfo,
+        doAddKnownTypes = doAddKnownTypes,
+        doAliasAnalysis = doAliasAnalysis,
+        doLiveVariablesAnalysis = doLiveVariablesAnalysis,
+    )
 
     override fun handleCrossUnitCall(
         caller: Vertex<ForwardTypeDomainFact, EtsStmt>,
@@ -25,13 +34,28 @@ class ForwardAnalyzer(
         error("No cross unit calls")
     }
 
+    private val liveVariablesCache = hashMapOf<EtsMethod, LiveVariables>()
+    private fun liveVariables(method: EtsMethod) =
+        liveVariablesCache.computeIfAbsent(method) {
+            if (doLiveVariablesAnalysis)
+                LiveVariables.from(method)
+            else
+                AlwaysAlive
+        }
+
     override fun handleNewEdge(edge: Edge<ForwardTypeDomainFact, EtsStmt>): List<AnalyzerEvent> {
         val (startVertex, currentVertex) = edge
         val (current, currentFact) = currentVertex
         val method = graph.methodOf(current)
         val currentIsExit = current in graph.exitPoints(method) ||
             (current is EtsNopStmt && graph.successors(current).none())
-        if (currentIsExit) {
+
+        val variableIsDying = (currentFact as? ForwardTypeDomainFact.TypedVariable)?.let {
+            val base = it.variable.base
+            base is AccessPathBase.Local && (!liveVariables(method).isAliveAt(base.name, current))
+        } ?: false
+
+        if (currentIsExit || variableIsDying) {
             return listOf(
                 ForwardSummaryAnalyzerEvent(
                     method = method,

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/ForwardAnalyzer.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/ForwardAnalyzer.kt
@@ -37,10 +37,7 @@ class ForwardAnalyzer(
     private val liveVariablesCache = hashMapOf<EtsMethod, LiveVariables>()
     private fun liveVariables(method: EtsMethod) =
         liveVariablesCache.computeIfAbsent(method) {
-            if (doLiveVariablesAnalysis)
-                LiveVariables.from(method)
-            else
-                AlwaysAlive
+            if (doLiveVariablesAnalysis) LiveVariables.from(method) else AlwaysAlive
         }
 
     override fun handleNewEdge(edge: Edge<ForwardTypeDomainFact, EtsStmt>): List<AnalyzerEvent> {

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/LiveVariables.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/LiveVariables.kt
@@ -29,9 +29,7 @@ interface LiveVariables {
         private const val THRESHOLD: Int = 20
 
         fun from(method: EtsMethod): LiveVariables =
-            if (method.cfg.stmts.size > THRESHOLD)
-                LiveVariablesImpl(method)
-            else AlwaysAlive
+            if (method.cfg.stmts.size > THRESHOLD) LiveVariablesImpl(method) else AlwaysAlive
     }
 }
 
@@ -40,7 +38,7 @@ object AlwaysAlive : LiveVariables {
 }
 
 class LiveVariablesImpl(
-    val method: EtsMethod
+    val method: EtsMethod,
 ) : LiveVariables {
     companion object {
         private fun EtsEntity.used(): List<String> = when (this) {

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/LiveVariables.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/LiveVariables.kt
@@ -1,0 +1,190 @@
+package org.usvm.dataflow.ts.infer
+
+import org.jacodb.ets.base.EtsArrayAccess
+import org.jacodb.ets.base.EtsAssignStmt
+import org.jacodb.ets.base.EtsBinaryExpr
+import org.jacodb.ets.base.EtsCallExpr
+import org.jacodb.ets.base.EtsCallStmt
+import org.jacodb.ets.base.EtsCastExpr
+import org.jacodb.ets.base.EtsEntity
+import org.jacodb.ets.base.EtsIfStmt
+import org.jacodb.ets.base.EtsInstanceCallExpr
+import org.jacodb.ets.base.EtsInstanceFieldRef
+import org.jacodb.ets.base.EtsInstanceOfExpr
+import org.jacodb.ets.base.EtsLocal
+import org.jacodb.ets.base.EtsReturnStmt
+import org.jacodb.ets.base.EtsStmt
+import org.jacodb.ets.base.EtsSwitchStmt
+import org.jacodb.ets.base.EtsTernaryExpr
+import org.jacodb.ets.base.EtsThrowStmt
+import org.jacodb.ets.base.EtsUnaryExpr
+import org.jacodb.ets.base.EtsValue
+import org.jacodb.ets.model.EtsMethod
+
+interface LiveVariables {
+    fun isAliveAt(local: String, stmt: EtsStmt): Boolean
+
+    companion object {
+        private const val THRESHOLD: Int = 20
+
+        fun from(method: EtsMethod): LiveVariables =
+            if (method.cfg.stmts.size > THRESHOLD)
+                LiveVariablesImpl(method)
+            else AlwaysAlive
+    }
+}
+
+object AlwaysAlive : LiveVariables {
+    override fun isAliveAt(local: String, stmt: EtsStmt): Boolean = true
+}
+
+class LiveVariablesImpl(
+    val method: EtsMethod
+) : LiveVariables {
+    companion object {
+        private fun EtsEntity.used(): List<String> = when (this) {
+            is EtsValue -> this.used()
+            is EtsUnaryExpr -> arg.used()
+            is EtsBinaryExpr -> left.used() + right.used()
+            is EtsCallExpr -> this.used()
+            is EtsCastExpr -> arg.used()
+            is EtsInstanceOfExpr -> arg.used()
+            is EtsTernaryExpr -> condition.used() + thenExpr.used() + elseExpr.used()
+            else -> emptyList()
+        }
+
+        private fun EtsValue.used(): List<String> = when (this) {
+            is EtsLocal -> listOf(name)
+            is EtsInstanceFieldRef -> listOf(instance.name)
+            is EtsArrayAccess -> array.used() + index.used()
+            else -> emptyList()
+        }
+
+        private fun EtsCallExpr.used(): List<String> = when (this) {
+            is EtsInstanceCallExpr -> listOf(instance.name) + args.flatMap { it.used() }
+            else -> args.flatMap { it.used() }
+        }
+
+        private fun <T> postOrder(sources: Iterable<T>, successors: (T) -> Iterable<T>): List<T> {
+            val order = mutableListOf<T>()
+            val visited = hashSetOf<T>()
+
+            fun dfs(node: T) {
+                visited.add(node)
+                for (next in successors(node)) {
+                    if (next !in visited)
+                        dfs(next)
+                }
+                order.add(node)
+            }
+
+            for (source in sources) {
+                if (source !in visited)
+                    dfs(source)
+            }
+
+            return order
+        }
+    }
+
+    private fun stronglyConnectedComponents(): IntArray {
+        val rpo = postOrder(method.cfg.entries) {
+            method.cfg.successors(it)
+        }.reversed()
+
+        val coloring = IntArray(method.cfg.stmts.size) { -1 }
+        var nextColor = 0
+        fun backwardDfs(stmt: EtsStmt) {
+            coloring[stmt.location.index] = nextColor
+            if (stmt in method.cfg.entries)
+                return
+            for (next in method.cfg.predecessors(stmt)) {
+                if (coloring[next.location.index] == -1) {
+                    backwardDfs(next)
+                }
+            }
+        }
+
+        for (stmt in rpo) {
+            if (coloring[stmt.location.index] == -1) {
+                backwardDfs(stmt)
+                nextColor++
+            }
+        }
+
+        return coloring
+    }
+
+    private fun condensation(coloring: IntArray): Map<Int, Set<Int>> {
+        val successors = hashMapOf<Int, HashSet<Int>>()
+        for (from in method.cfg.stmts) {
+            for (to in method.cfg.successors(from)) {
+                val fromColor = coloring[from.location.index]
+                val toColor = coloring[to.location.index]
+                if (fromColor != toColor) {
+                    successors.computeIfAbsent(fromColor) { hashSetOf() }
+                        .add(toColor)
+                }
+            }
+        }
+        return successors
+    }
+
+    private val lifetime = hashMapOf<String, Pair<Int, Int>>()
+    private val coloring = stronglyConnectedComponents()
+    private val colorIndex: IntArray
+
+    init {
+        val condensationSuccessors = condensation(coloring)
+        val entriesColors = method.cfg.entries.map {
+            coloring[it.location.index]
+        }
+        val colorOrder = postOrder(entriesColors) {
+            condensationSuccessors[it].orEmpty()
+        }.reversed()
+
+        colorIndex = IntArray(colorOrder.size) { -1 }
+        for ((index, color) in colorOrder.withIndex()) {
+            colorIndex[color] = index
+        }
+
+        val ownLocals = hashSetOf<String>()
+        for (stmt in method.cfg.stmts) {
+            if (stmt is EtsAssignStmt) {
+                when (val lhv = stmt.lhv) {
+                    is EtsLocal -> ownLocals.add(lhv.name)
+                }
+            }
+        }
+
+        for (stmt in method.cfg.stmts) {
+            val usedLocals = when (stmt) {
+                is EtsAssignStmt -> stmt.lhv.used() + stmt.rhv.used()
+                is EtsCallStmt -> stmt.expr.used()
+                is EtsReturnStmt -> stmt.returnValue?.used().orEmpty()
+                is EtsIfStmt -> stmt.condition.used()
+                is EtsSwitchStmt -> stmt.arg.used()
+                is EtsThrowStmt -> stmt.arg.used()
+                else -> emptyList()
+            }
+            val blockIndex = colorIndex[coloring[stmt.location.index]]
+
+            for (local in usedLocals) {
+                if (local in ownLocals) {
+                    lifetime.merge(local, blockIndex to blockIndex) { (begin, end), (bb, be) ->
+                        minOf(begin, bb) to maxOf(end, be)
+                    }
+                } else {
+                    lifetime[local] = Int.MIN_VALUE to Int.MAX_VALUE
+                }
+            }
+        }
+    }
+
+    override fun isAliveAt(local: String, stmt: EtsStmt): Boolean {
+        if (stmt.location.index < 0) return true
+        val block = colorIndex[coloring[stmt.location.index]]
+        val (begin, end) = lifetime[local] ?: error("Unknown local")
+        return block in begin..end
+    }
+}

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/TypeInferenceManager.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/TypeInferenceManager.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import mu.KotlinLogging
-import org.jacodb.ets.base.ANONYMOUS_CLASS_PREFIX
 import org.jacodb.ets.base.CONSTRUCTOR_NAME
 import org.jacodb.ets.base.EtsReturnStmt
 import org.jacodb.ets.base.EtsStmt
@@ -193,7 +192,8 @@ class TypeInferenceManager(
             typeInfo,
             doAddKnownTypes,
             doAliasAnalysis = true,
-            doLiveVariablesAnalysis = true)
+            doLiveVariablesAnalysis = true,
+        )
 
         val forwardRunner = UniRunner(
             traits = traits,

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/TypeInferenceManager.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/TypeInferenceManager.kt
@@ -344,8 +344,7 @@ class TypeInferenceManager(
             .entries.groupByTo(hashMapOf()) { (method, _) -> method.enclosingClass }
 
         return graph.cp.projectClasses.mapNotNull { cls ->
-            val clsMethods = (cls.methods + cls.ctor).toHashSet()
-            val combinedBackwardType = clsMethods
+            val combinedBackwardType = (cls.methods + cls.ctor)
                 .mapNotNull { methodTypeScheme[it] }
                 .mapNotNull { facts -> facts[AccessPathBase.This] }.reduceOrNull { acc, type ->
                     typeProcessor.intersect(acc, type) ?: run {

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/TypeInferenceManager.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/TypeInferenceManager.kt
@@ -79,10 +79,12 @@ class TypeInferenceManager(
         allMethods: List<EtsMethod> = entrypoints,
         doAddKnownTypes: Boolean = true,
         doInferAllLocals: Boolean = true,
+        doAliasAnalysis: Boolean = true,
     ): TypeInferenceResult = runBlocking {
         val methodTypeScheme = collectSummaries(
             startMethods = entrypoints,
             doAddKnownTypes = doAddKnownTypes,
+            doAliasAnalysis = doAliasAnalysis,
         )
         val remainingMethodsForAnalysis = allMethods.filter { it !in methodTypeScheme.keys }
 
@@ -92,6 +94,7 @@ class TypeInferenceManager(
             collectSummaries(
                 startMethods = remainingMethodsForAnalysis,
                 doAddKnownTypes = doAddKnownTypes,
+                doAliasAnalysis = doAliasAnalysis,
             )
         }
 
@@ -104,6 +107,7 @@ class TypeInferenceManager(
     private suspend fun collectSummaries(
         startMethods: List<EtsMethod>,
         doAddKnownTypes: Boolean = true,
+        doAliasAnalysis: Boolean = true,
     ): Map<EtsMethod, Map<AccessPathBase, EtsTypeFact>> {
         logger.info { "Preparing backward analysis" }
         val backwardGraph = graph.reversed
@@ -191,7 +195,7 @@ class TypeInferenceManager(
             methodTypeScheme,
             typeInfo,
             doAddKnownTypes,
-            doAliasAnalysis = true,
+            doAliasAnalysis = doAliasAnalysis,
             doLiveVariablesAnalysis = true,
         )
 

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/cli/InferTypes.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/cli/InferTypes.kt
@@ -70,6 +70,11 @@ class InferTypes : CliktCommand() {
         help = "Do take into account the known types in scene"
     ).flag("--no-use-known-types", default = true)
 
+    val enableAliasAnalysis by option(
+        "--alias-analysis",
+        help = "Enable alias analysis"
+    ).flag("--no-alias-analysis", default = true)
+
     override fun run() {
         logger.info { "Running InferTypes" }
         val startTime = System.currentTimeMillis()
@@ -91,6 +96,7 @@ class InferTypes : CliktCommand() {
                 entrypoints = dummyMains,
                 allMethods = publicMethods,
                 doAddKnownTypes = useKnownTypes,
+                doAliasAnalysis = enableAliasAnalysis,
             )
         }
         logger.info { "Inferred types for ${resultBasic.inferredTypes.size} methods in $timeAnalyze" }

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/util/EtsTraits.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/util/EtsTraits.kt
@@ -27,7 +27,6 @@ import org.jacodb.ets.base.EtsAssignStmt
 import org.jacodb.ets.base.EtsBinaryExpr
 import org.jacodb.ets.base.EtsBooleanConstant
 import org.jacodb.ets.base.EtsCallExpr
-import org.jacodb.ets.base.EtsCallStmt
 import org.jacodb.ets.base.EtsCastExpr
 import org.jacodb.ets.base.EtsClassType
 import org.jacodb.ets.base.EtsConstant
@@ -99,11 +98,7 @@ class EtsTraits : Traits<EtsMethod, EtsStmt> {
     }
 
     override fun getCallExpr(statement: EtsStmt): EtsCallExpr? {
-        return when (statement) {
-            is EtsAssignStmt -> statement.rhv as? EtsCallExpr
-            is EtsCallStmt -> statement.expr
-            else -> null
-        }
+        return statement.callExpr
     }
 
     override fun getValues(expr: CommonExpr): Set<CommonValue> {

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/util/EtsTraits.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/util/EtsTraits.kt
@@ -27,6 +27,7 @@ import org.jacodb.ets.base.EtsAssignStmt
 import org.jacodb.ets.base.EtsBinaryExpr
 import org.jacodb.ets.base.EtsBooleanConstant
 import org.jacodb.ets.base.EtsCallExpr
+import org.jacodb.ets.base.EtsCallStmt
 import org.jacodb.ets.base.EtsCastExpr
 import org.jacodb.ets.base.EtsClassType
 import org.jacodb.ets.base.EtsConstant
@@ -98,7 +99,11 @@ class EtsTraits : Traits<EtsMethod, EtsStmt> {
     }
 
     override fun getCallExpr(statement: EtsStmt): EtsCallExpr? {
-        return statement.callExpr
+        return when (statement) {
+            is EtsAssignStmt -> statement.rhv as? EtsCallExpr
+            is EtsCallStmt -> statement.expr
+            else -> null
+        }
     }
 
     override fun getValues(expr: CommonExpr): Set<CommonValue> {

--- a/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsTypeResolverPerformanceTest.kt
+++ b/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsTypeResolverPerformanceTest.kt
@@ -76,13 +76,14 @@ class EtsTypeResolverPerformanceTest {
             )
         )
 
-        val file = File(OUTPUT_FILE)
-        file.writeText(buildString {
+        val reportStr = buildString {
             appendLine("|project|min time|max time|avg time|median time|%|")
             appendLine("|:--|:--|:--|:--|:--|:--|")
             reports.forEach {
                 appendLine(it.dumpToString())
             }
-        })
+        }
+        val file = File(OUTPUT_FILE)
+        file.writeText(reportStr)
     }
 }

--- a/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsTypeResolverPerformanceTest.kt
+++ b/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsTypeResolverPerformanceTest.kt
@@ -28,8 +28,8 @@ import java.io.File
 @Disabled
 class EtsTypeResolverPerformanceTest {
     companion object {
-        const val WARMUP_ITERATIONS = 0
-        const val TEST_ITERATIONS = 10
+        const val WARMUP_ITERATIONS = 5
+        const val TEST_ITERATIONS = 5
         const val OUTPUT_FILE = "performance_report.md"
 
         @JvmStatic

--- a/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsTypeResolverPerformanceTest.kt
+++ b/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsTypeResolverPerformanceTest.kt
@@ -28,7 +28,8 @@ import java.io.File
 @Disabled
 class EtsTypeResolverPerformanceTest {
     companion object {
-        const val RUNS = 5
+        const val WARMUP_ITERATIONS = 0
+        const val TEST_ITERATIONS = 10
         const val OUTPUT_FILE = "performance_report.md"
 
         @JvmStatic
@@ -38,7 +39,7 @@ class EtsTypeResolverPerformanceTest {
     }
 
     private fun runOnAbcProject(projectID: String, abcPath: String): PerformanceReport {
-        val report = generateReportForProject(projectID, abcPath, RUNS)
+        val report = generateReportForProject(projectID, abcPath, WARMUP_ITERATIONS, TEST_ITERATIONS)
         return report
     }
 
@@ -76,14 +77,12 @@ class EtsTypeResolverPerformanceTest {
         )
 
         val file = File(OUTPUT_FILE)
-        file.writeText(
-            buildString {
-                appendLine("|project|min time|max time|%|")
-                appendLine("|:--|:--|:--|:--|")
-                reports.forEach {
-                    appendLine(it.dumpToString())
-                }
+        file.writeText(buildString {
+            appendLine("|project|min time|max time|avg time|median time|%|")
+            appendLine("|:--|:--|:--|:--|:--|:--|")
+            reports.forEach {
+                appendLine(it.dumpToString())
             }
-        )
+        })
     }
 }

--- a/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/utils/PerformanceReport.kt
+++ b/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/utils/PerformanceReport.kt
@@ -48,7 +48,7 @@ fun generateReportForProject(
     projectId: String,
     abcPath: String,
     warmupIterationsCount: Int,
-    runIterationsCount: Int
+    runIterationsCount: Int,
 ): PerformanceReport {
     val abcScene = AbcProjects.getAbcProject(abcPath)
 

--- a/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/utils/PerformanceReport.kt
+++ b/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/utils/PerformanceReport.kt
@@ -16,20 +16,27 @@
 
 package org.usvm.dataflow.ts.test.utils
 
+import java.math.RoundingMode
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
 import kotlin.time.measureTimedValue
+
 
 data class PerformanceReport(
     val projectId: String,
     val maxTime: Duration,
+    val avgTime: Duration,
+    val medianTime: Duration,
     val minTime: Duration,
     val improvement: Double,
 ) {
     fun dumpToString(): String = listOf<Any>(
         projectId,
-        minTime,
-        maxTime,
-        improvement
+        minTime.toString(unit = DurationUnit.SECONDS, decimals = 3),
+        maxTime.toString(unit = DurationUnit.SECONDS, decimals = 3),
+        avgTime.toString(unit = DurationUnit.SECONDS, decimals = 3),
+        medianTime.toString(unit = DurationUnit.SECONDS, decimals = 3),
+        improvement.toBigDecimal().setScale(4, RoundingMode.HALF_UP).toDouble()
     ).joinToString(
         separator = "|",
         prefix = "|",
@@ -40,24 +47,29 @@ data class PerformanceReport(
 fun generateReportForProject(
     projectId: String,
     abcPath: String,
-    runCount: Int,
+    warmupIterationsCount: Int,
+    runIterationsCount: Int
 ): PerformanceReport {
     val abcScene = AbcProjects.getAbcProject(abcPath)
 
-    val results = List(runCount) {
-        val (statistics, time) = measureTimedValue {
-            AbcProjects.runOnAbcProject(abcScene).second
+    val results = List(warmupIterationsCount + runIterationsCount) {
+        val (result, time) = measureTimedValue {
+            AbcProjects.inferTypes(abcScene)
         }
+        val statistics = AbcProjects.calculateStatistics(abcScene, result)
         time to statistics.calculateImprovement()
-    }
+    }.drop(warmupIterationsCount)
 
     val times = results.map { it.first }
-    val improvement = results.map { it.second }.distinct().single()
+    val improvement = results.map { it.second }.distinct().first()
+    val totalTime = times.reduce { acc, duration -> acc + duration }
 
     return PerformanceReport(
         projectId = projectId,
         minTime = times.min(),
         maxTime = times.max(),
+        avgTime = totalTime / runIterationsCount,
+        medianTime = times.sorted()[runIterationsCount / 2],
         improvement = improvement
     )
 }


### PR DESCRIPTION
- Add liveness analysis before type inference
  - `ForwardAnalyzer` stores facts about the variable immediately after the last instruction where the variable was used and `ForwardFlowFunction` drops facts about dead variables. This pre-analysis slightly increases the total performance without loss of precision.
- Fixed tests: now we doesn't take into account time spent to compute statistics
- Add flags for `ForwardAnalyzer` and `ForwardFlowFunctions` to enable/disable pre-analysis (alias and/or liveness)
- Add index to speed up callee resolver