### PR TITLE
Bump JacoDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           DEST_DIR="arkanalyzer"
           MAX_RETRIES=10
           RETRY_DELAY=3  # Delay between retries in seconds  
-          BRANCH="neo/2025-05-12"
+          BRANCH="neo/2025-05-30b"
 
           for ((i=1; i<=MAX_RETRIES; i++)); do
               git clone --depth=1 --branch $BRANCH $REPO_URL $DEST_DIR && break

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,7 +6,7 @@ object Versions {
     const val clikt = "5.0.0"
     const val detekt = "1.23.7"
     const val ini4j = "0.5.4"
-    const val jacodb = "3b6a17f000"
+    const val jacodb = "4ca8d08f1d"
     const val juliet = "1.3.2"
     const val junit = "5.9.3"
     const val kotlin = "2.1.0"

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/dto/EtsTypeToDto.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/dto/EtsTypeToDto.kt
@@ -21,6 +21,7 @@ import org.jacodb.ets.dto.AnyTypeDto
 import org.jacodb.ets.dto.ArrayTypeDto
 import org.jacodb.ets.dto.BooleanTypeDto
 import org.jacodb.ets.dto.ClassTypeDto
+import org.jacodb.ets.dto.EnumValueTypeDto
 import org.jacodb.ets.dto.FunctionTypeDto
 import org.jacodb.ets.dto.GenericTypeDto
 import org.jacodb.ets.dto.IntersectionTypeDto
@@ -43,6 +44,7 @@ import org.jacodb.ets.model.EtsAnyType
 import org.jacodb.ets.model.EtsArrayType
 import org.jacodb.ets.model.EtsBooleanType
 import org.jacodb.ets.model.EtsClassType
+import org.jacodb.ets.model.EtsEnumValueType
 import org.jacodb.ets.model.EtsFunctionType
 import org.jacodb.ets.model.EtsGenericType
 import org.jacodb.ets.model.EtsIntersectionType
@@ -94,6 +96,13 @@ private object EtsTypeToDto : EtsType.Visitor<TypeDto> {
                 type.signature.name,
                 type.signature.method.toDto(),
             ),
+        )
+    }
+
+    override fun visit(type: EtsEnumValueType): TypeDto {
+        return EnumValueTypeDto(
+            signature = type.signature.toDto(),
+            constant = type.constant?.toDto(),
         )
     }
 

--- a/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/dto/EtsValueToDto.kt
+++ b/usvm-ts-dataflow/src/main/kotlin/org/usvm/dataflow/ts/infer/dto/EtsValueToDto.kt
@@ -40,43 +40,43 @@ import org.jacodb.ets.model.EtsValue
 
 fun EtsValue.toDto(): ValueDto = accept(EtsValueToDto)
 
-private object EtsValueToDto : EtsValue.Visitor<ValueDto> {
-    override fun visit(value: EtsLocal): ValueDto {
-        return LocalDto(
-            name = value.name,
-            type = value.type.toDto(),
-        )
-    }
+fun EtsLocal.toDto(): LocalDto = LocalDto(
+    name = name,
+    type = type.toDto(),
+)
 
-    private fun visitConstant(value: EtsConstant): ValueDto {
-        return ConstantDto(
-            value = value.toString(),
-            type = value.type.toDto(),
-        )
+fun EtsConstant.toDto(): ConstantDto = ConstantDto(
+    value = toString(),
+    type = type.toDto(),
+)
+
+private object EtsValueToDto : EtsValue.Visitor<ValueDto> {
+    override fun visit(value: EtsLocal): LocalDto {
+        return value.toDto()
     }
 
     override fun visit(value: EtsConstant): ValueDto {
-        return visitConstant(value)
+        return value.toDto()
     }
 
     override fun visit(value: EtsStringConstant): ValueDto {
-        return visitConstant(value)
+        return value.toDto()
     }
 
     override fun visit(value: EtsBooleanConstant): ValueDto {
-        return visitConstant(value)
+        return value.toDto()
     }
 
     override fun visit(value: EtsNumberConstant): ValueDto {
-        return visitConstant(value)
+        return value.toDto()
     }
 
     override fun visit(value: EtsNullConstant): ValueDto {
-        return visitConstant(value)
+        return value.toDto()
     }
 
     override fun visit(value: EtsUndefinedConstant): ValueDto {
-        return visitConstant(value)
+        return value.toDto()
     }
 
     override fun visit(value: EtsThis): ValueDto {


### PR DESCRIPTION
This PR bumps jacodb to the latest commit (https://github.com/UnitTestBot/jacodb/commit/4ca8d08f1d8c15797fbc26c14e977b8f2426658d), and also bumps ArkAnalyzer to branch `neo/2025-05-30b`. Overall, it introduces the support for `EnumValueType`.