### PR TITLE
Enable Gradle Build Scans

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,8 +21,9 @@ develocity {
         termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
         termsOfUseAgree.set("yes")
 
-        // Publish build scans on-demand, when `--scan` option is provided:
-        publishing.onlyIf { false }
+        // In CI, publish build scans automatically.
+        // Locally, publish build scans on-demand, when `--scan` option is provided:
+        publishing.onlyIf { System.getProperty("CI") != null }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,31 @@
 rootProject.name = "usvm"
 
+pluginManagement {
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.name == "rdgen") {
+                useModule("com.jetbrains.rd:rd-gen:${requested.version}")
+            }
+        }
+    }
+}
+
+plugins {
+    // https://plugins.gradle.org/plugin/com.gradle.develocity
+    id("com.gradle.develocity") version("4.0.2")
+}
+
+develocity {
+    buildScan {
+        // Accept the term of use for the build scan plugin:
+        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+        termsOfUseAgree.set("yes")
+
+        // Publish build scans on-demand, when `--scan` option is provided:
+        publishing.onlyIf { false }
+    }
+}
+
 include("usvm-core")
 include("usvm-jvm")
 include("usvm-jvm:usvm-jvm-api")
@@ -29,13 +55,3 @@ findProject(":usvm-python:usvm-python-commons")?.name = "usvm-python-commons"
 // As a workaround, we convert it to a real absolute path.
 // See IDEA bug: https://youtrack.jetbrains.com/issue/IDEA-329756
 // includeBuild(file("../jacodb").toPath().toRealPath().toAbsolutePath())
-
-pluginManagement {
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.name == "rdgen") {
-                useModule("com.jetbrains.rd:rd-gen:${requested.version}")
-            }
-        }
-    }
-}


### PR DESCRIPTION
This PR enables [Gradle Build Scans](https://docs.gradle.org/current/userguide/build_scans.html).
- On CI (i.e. when `CI` env var is present), build scan publishing is turned on automatically (pass `--no-scan` to disable).
- Locally, build scans publishing is turned off. Pass `--scan` manually to publish a build scan.