### PR TITLE
Fix publishing Build Scans on CI

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,7 @@ develocity {
 
         // In CI, publish build scans automatically.
         // Locally, publish build scans on-demand, when `--scan` option is provided:
-        publishing.onlyIf { System.getProperty("CI") != null }
+        publishing.onlyIf { System.getenv("CI") != null }
     }
 }
 


### PR DESCRIPTION
This PR fixes the automatic publishing of Gradle Build Scans in CI environment by correctly using `System.getenv` instead of `System.getProperty`.

Test locally with `CI=true gw compileKotlin`, this produces a build scan even without the `--scan` option.