### PR TITLE
Update jacodb

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,7 +6,7 @@ object Versions {
     const val clikt = "5.0.0"
     const val detekt = "1.23.7"
     const val ini4j = "0.5.4"
-    const val jacodb = "da338ffc83"
+    const val jacodb = "d7dd9d343b"
     const val juliet = "1.3.2"
     const val junit = "5.9.3"
     const val kotlin = "2.1.0"

--- a/usvm-jvm/src/main/kotlin/org/usvm/util/JcApproximationUtils.kt
+++ b/usvm-jvm/src/main/kotlin/org/usvm/util/JcApproximationUtils.kt
@@ -44,7 +44,7 @@ suspend fun JcDatabase.classpathWithApproximations(
     val approximationsPath = setOf(File(usvmApiJarPath), File(usvmApproximationsJarPath))
 
     val cpWithApproximations = dirOrJars + approximationsPath
-    val featuresWithApproximations = features + listOf(Approximations)
+    val featuresWithApproximations = features + listOf(Approximations(emptyList()))
     val cp = classpath(cpWithApproximations, featuresWithApproximations.distinct())
 
     val approximationsLocations = cp.locations.filter { it.jarOrFolder in approximationsPath }

--- a/usvm-jvm/src/test/kotlin/org/usvm/samples/JacoDBContainer.kt
+++ b/usvm-jvm/src/test/kotlin/org/usvm/samples/JacoDBContainer.kt
@@ -28,7 +28,7 @@ class JacoDBContainer(
                 builder()
 
                 if (samplesWithApproximationsKey == key) {
-                    installFeatures(Approximations)
+                    installFeatures(Approximations(emptyList()))
                 }
 
                 loadByteCode(classpath)


### PR DESCRIPTION
This PR bumps jacodb to the latest version (https://github.com/UnitTestBot/jacodb/commit/d7dd9d343b58429d286c888a0d1296fa735eef37).

@saloed Please check that it is correct to create `Approximations(emptyList())` with empty version infos.