### PR TITLE
[TS] Improve performance of EtsHierarchy

### DIFF
--- a/usvm-ts/src/main/kotlin/org/usvm/util/EtsHierarchy.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/util/EtsHierarchy.kt
@@ -22,7 +22,9 @@ class EtsHierarchy(private val scene: EtsScene) {
                 classes
                     .groupBy { it.signature }
                     .mapValues { it.value.single() }
+                    .let { HashMap(it) }
             }
+            .let { HashMap(it) }
     }
 
     private val ancestors: Map<EtsClass, Set<EtsClass>> by lazy {
@@ -111,7 +113,7 @@ class EtsHierarchy(private val scene: EtsScene) {
 
         if (etsClassType.isResolved()) {
             val signature = (etsClassType as EtsClassType).signature.copy(name = typeName)
-            return suitableClasses[signature]?.let { hashSetOf(it) } ?: emptySet()
+            return suitableClasses[signature]?.let { setOf(it) } ?: emptySet()
         }
 
         return suitableClasses.values


### PR DESCRIPTION
This PR improves the performance of `EtsHierarchy` by using hash maps, but also by using `setOf(x)` instead of `hashSetOf(x)`, since `setOf(x)` is overloaded in Kotlin to provide more performant _singleton_ set.