### PR TITLE
Bump jacodb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           DEST_DIR="arkanalyzer"
           MAX_RETRIES=10
           RETRY_DELAY=3  # Delay between retries in seconds  
-          BRANCH="neo/2025-07-18"
+          BRANCH="neo/2025-08-12"
 
           for ((i=1; i<=MAX_RETRIES; i++)); do
               git clone --depth=1 --branch $BRANCH $REPO_URL $DEST_DIR && break

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,7 +6,7 @@ object Versions {
     const val clikt = "5.0.0"
     const val detekt = "1.23.7"
     const val ini4j = "0.5.4"
-    const val jacodb = "f3655cbc5d"
+    const val jacodb = "d3e97200d6"
     const val juliet = "1.3.2"
     const val junit = "5.9.3"
     const val kotlin = "2.1.0"

--- a/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsSceneTest.kt
+++ b/usvm-ts-dataflow/src/test/kotlin/org/usvm/dataflow/ts/test/EtsSceneTest.kt
@@ -149,7 +149,7 @@ class EtsSceneTest {
                 blocks = blocks,
                 successors = successors,
             )
-            it._cfg = cfg
+            it.body.cfg = cfg
         }
         val ctorBox = EtsMethodImpl(
             signature = EtsMethodSignature(

--- a/usvm-ts/src/main/kotlin/org/usvm/util/BuildEtsMethod.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/util/BuildEtsMethod.kt
@@ -33,7 +33,7 @@ fun buildEtsMethod(
     val prog = program(program)
     val blockCfg = prog.toBlockCfg()
     val etsCfg = blockCfg.toEtsBlockCfg(method)
-    method._cfg = etsCfg
+    method.body.cfg = etsCfg
 
     ((enclosingClass as EtsClassImpl).methods as MutableList).add(method)
     method.enclosingClass = enclosingClass


### PR DESCRIPTION
This PR bumps jacodb to https://github.com/UnitTestBot/jacodb/commit/d3e97200d62f959ebb430cb79817861554cc9805 and also updates ArkAnalyzer to branch `neo/2025-08-12` to align with jacodb.