### PR TITLE
[TS] Handle null == undefined

### DIFF
--- a/usvm-ts/src/main/kotlin/org/usvm/machine/operator/TsBinaryOperator.kt
+++ b/usvm-ts/src/main/kotlin/org/usvm/machine/operator/TsBinaryOperator.kt
@@ -384,6 +384,9 @@ sealed interface TsBinaryOperator {
             rhs: UHeapRef,
             scope: TsStepScope,
         ): UBoolExpr {
+            // Note: in JavaScript, `undefined == null`
+            if (lhs == mkUndefinedValue() && rhs == mkTsNullValue()) return mkTrue()
+            if (lhs == mkTsNullValue() && rhs == mkUndefinedValue()) return mkTrue()
             return mkEq(lhs, rhs)
         }
 

--- a/usvm-ts/src/test/kotlin/org/usvm/samples/operators/Equality.kt
+++ b/usvm-ts/src/test/kotlin/org/usvm/samples/operators/Equality.kt
@@ -133,4 +133,52 @@ class Equality : TsMethodTestRunner() {
             )
         )
     }
+
+    @Test
+    fun `test eqNullWithNull`() {
+        val method = getMethod("eqNullWithNull")
+        discoverProperties<TsTestValue.TsNumber>(
+            method,
+            { r -> r eq 1 },
+            invariants = arrayOf(
+                { r -> r.number > 0 },
+            )
+        )
+    }
+
+    @Test
+    fun `test eqUndefinedWithUndefined`() {
+        val method = getMethod("eqUndefinedWithUndefined")
+        discoverProperties<TsTestValue.TsNumber>(
+            method,
+            { r -> r eq 1 },
+            invariants = arrayOf(
+                { r -> r.number > 0 },
+            )
+        )
+    }
+
+    @Test
+    fun `test eqNullWithUndefined`() {
+        val method = getMethod("eqNullWithUndefined")
+        discoverProperties<TsTestValue.TsNumber>(
+            method,
+            { r -> r eq 1 },
+            invariants = arrayOf(
+                { r -> r.number > 0 },
+            )
+        )
+    }
+
+    @Test
+    fun `test eqUndefinedWithNull`() {
+        val method = getMethod("eqUndefinedWithNull")
+        discoverProperties<TsTestValue.TsNumber>(
+            method,
+            { r -> r eq 1 },
+            invariants = arrayOf(
+                { r -> r.number > 0 },
+            )
+        )
+    }
 }

--- a/usvm-ts/src/test/resources/samples/operators/Equality.ts
+++ b/usvm-ts/src/test/resources/samples/operators/Equality.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 // noinspection JSUnusedGlobalSymbols
+// noinspection PointlessBooleanExpressionJS
 
 class Equality {
     eqBoolWithBool(a: boolean): number {
@@ -54,5 +55,25 @@ class Equality {
         if ([1] == false) return -1; // unreachable
         if ([42] == false) return -1; // unreachable
         return 0;
+    }
+
+    eqNullWithNull(): number {
+        if (null == null) return 1;
+        return -1; // unreachable
+    }
+
+    eqUndefinedWithUndefined(): number {
+        if (undefined == undefined) return 1;
+        return -1; // unreachable
+    }
+
+    eqNullWithUndefined(): number {
+        if (null == undefined) return 1;
+        return -1; // unreachable
+    }
+
+    eqUndefinedWithNull(): number {
+        if (undefined == null) return 1;
+        return -1; // unreachable
     }
 }


### PR DESCRIPTION
This PR fixes `TsBinaryOperator.Eq::onRef` for two heap refs which can represent `null` or `undefined` JS values, which are actually loosely equal (`null == undefined`, but _not_ `null === undefined`), despite having different addresses. Other objects are compared via refs in JS, which is correctly translated to `mkHeapRefEq`.