### PR TITLE
Less restrictions in the memory

### DIFF
--- a/usvm-core/src/main/kotlin/org/usvm/Context.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/Context.kt
@@ -98,7 +98,7 @@ open class UContext<USizeSort : USort>(
         return nullRef
     }
 
-    val addressCounter = UAddressCounter()
+    open val addressCounter = UAddressCounter()
 
     fun mkAddressCounter(): UAddressCounter {
         return addressCounter

--- a/usvm-core/src/main/kotlin/org/usvm/memory/Memory.kt
+++ b/usvm-core/src/main/kotlin/org/usvm/memory/Memory.kt
@@ -93,13 +93,13 @@ interface UWritableMemory<Type> : UReadOnlyMemory<Type> {
 }
 
 @Suppress("MemberVisibilityCanBePrivate")
-class UMemory<Type, Method>(
-    internal val ctx: UContext<*>,
+open class UMemory<Type, Method>(
+    val ctx: UContext<*>,
     override var ownership: MutabilityOwnership,
     override val types: UTypeConstraints<Type>,
     override val stack: URegistersStack = URegistersStack(),
-    private val mocks: UIndexedMocker<Method> = UIndexedMocker(),
-    private var regions: UPersistentHashMap<UMemoryRegionId<*, *>, UMemoryRegion<*, *>> = persistentHashMapOf(),
+    val mocks: UIndexedMocker<Method> = UIndexedMocker(),
+    var regions: UPersistentHashMap<UMemoryRegionId<*, *>, UMemoryRegion<*, *>> = persistentHashMapOf(),
 ) : UWritableMemory<Type>, UOwnedMergeable<UMemory<Type, Method>, MergeGuard> {
 
     override val mocker: UMocker<Method>
@@ -155,7 +155,7 @@ class UMemory<Type, Method>(
 
     override fun nullRef(): UHeapRef = ctx.nullRef
 
-    fun clone(
+    open fun clone(
         typeConstraints: UTypeConstraints<Type>,
         thisOwnership: MutabilityOwnership,
         cloneOwnership: MutabilityOwnership,


### PR DESCRIPTION
Relaxed the modifiers (added open, downgraded access modifiers) so that it is possible to create a memory-local addresses allocations (which allows for path selector-independent addresses, helpful for debugging).